### PR TITLE
Change workflow and add wrong prefix message

### DIFF
--- a/buttercup/cogs/restrictor.py
+++ b/buttercup/cogs/restrictor.py
@@ -49,14 +49,14 @@ class Record:
         self, nickname: str = None, coc: bool = False, restricted: bool = True
     ) -> None:
         """
-        Initialize the user record.
+        Initialize the member record.
 
         The record contains the following fields:
         - nickname: The nickname of the member
         - coc: Whether the member has accepted the Code of Conduct
         - restricted: Whether the member has restricted access to Discord
         - compliant: Whether the member complies with all set constraints
-        - new_user: Whether the member is a new user
+        - new_member: Whether the member is new
         - correct_nickname: Whether the member's nickname is correct
         """
         self.nickname = nickname
@@ -69,8 +69,8 @@ class Record:
         return self.coc and self.correct_nickname
 
     @property
-    def new_user(self) -> bool:
-        """Whether the member is a new user."""
+    def new_member(self) -> bool:
+        """Whether the member is new."""
         return all([not self.coc, self.nickname is None])
 
     @property
@@ -78,7 +78,7 @@ class Record:
         """
         Whether a nickname is correct.
 
-        This check is currently only based on whether the username starts with
+        This check is currently only based on whether the nickname starts with
         "/u/", but can be extended.
         """
         return self.nickname is not None and self.nickname.startswith("/u/")
@@ -93,7 +93,7 @@ class Restrictor(Cog):
         restrict_channel: str,
         welcome_channel: str,
     ) -> None:
-        """Initialize the user dictionary and retrieve the relevant roles and channels."""
+        """Initialize the member's records and retrieve the roles and channels."""
         self.bot = bot
         self.restrict_name = restrict_role
         self.accepted_name = accepted_role
@@ -160,8 +160,8 @@ class Restrictor(Cog):
           the correctness of its format
         """
         channel = self.welcome_channel if new.compliant else self.restrict_channel
-        first_time_user = len(set(member.roles).difference({self.restrict_role})) == 1
-        if old is None and new.new_user:
+        first_time_member = len(set(member.roles).difference({self.restrict_role})) == 1
+        if old is None and new.new_member:
             await member.add_roles(self.restrict_role)
             await self._send_message(channel, "new_member", member)
             return
@@ -169,7 +169,7 @@ class Restrictor(Cog):
         if new.restricted and new.compliant:
             # Remove restriction
             await member.remove_roles(self.restrict_role)
-            if first_time_user:
+            if first_time_member:
                 # They are unrestricted first time, welcome in channel.
                 await self._send_message(channel, "new_lifted", member)
                 await member.add_roles(self.accepted_role)

--- a/buttercup/strings/en_US.yaml
+++ b/buttercup/strings/en_US.yaml
@@ -15,13 +15,15 @@ restrictor:
     If you have any questions or remarks, feel free to send a message in this channel and one of our moderators will be with you shortly! Cheers!
   coc_accepted: |
     Hey <@{0}>, we're glad you have read and accepted our Code of Conduct. This has been noted! :+1:
-  wrong_username: |
-    Hey <@{0}>, it appears that you have changed your username back to something that is not compliant with our guidelines.
+  correct_nick: |
+    Hey <@{0}>, thank you for changing your nickname to the specified format!
+  wrong_nick: |
+    Hey <@{0}>, it appears that you have changed your nickname to something that is not compliant with our guidelines.
 
     Make sure to use your Reddit name in Discord by typing `/nick /u/REDDIT_USERNAME`, replacing "REDDIT_USERNAME" with your actual Reddit username.
 
-    If you have changed your username back to a correct one, the restriction will be lifted.
-
     If you have any questions or remarks, feel free to send a message in this channel and one of our moderators will be with you shortly! Cheers!
-  restriction_lifted: |
-    Welcome once again <@{0}> to the Transcribers of Reddit Discord! Since you have accepted our Code of Conduct and changed your nickname to the correct format, you now have unrestricted access to our Discord. Thanks for your time and enjoy your time in here!
+  wrong_prefix: |
+    Hey <@{0}>, it appears that you have attempted to change your nickname, but forgot the initial `/` in your nickname. Make sure that your nickname starts with `/u/` and not `u/`!
+  new_lifted: |
+    Welcome <@{0}> to the Transcribers of Reddit Discord! Since you have accepted our Code of Conduct and changed your nickname to the correct format, you now have unrestricted access to our Discord. Thanks for your time and enjoy your time in here!


### PR DESCRIPTION
## Description:

In this PR, the "Restrictor" cog is further updated to send a message based on whether the nickname starts with the `u/` prefix rather than `/u/`. To allow this to be done in a systematic way, the workflow has been reworked using an Observer pattern, where the restrictor keeps track of a Record for each encountered member, which triggers a set of conditional handlings when this record is updated.
{description}

## Checklist:

- [X] Code Quality
- [X] Pep-8
- [X] Success Criteria Met
- [X] Inline Documentation