### PR TITLE
Add ping command

### DIFF
--- a/buttercup/cogs/ping.py
+++ b/buttercup/cogs/ping.py
@@ -1,0 +1,59 @@
+from datetime import datetime
+
+from blossom_wrapper import BlossomAPI
+from discord import Color, Embed
+from discord.ext.commands import Cog
+from discord_slash import SlashContext, cog_ext
+
+from buttercup.bot import ButtercupBot
+
+
+class Ping(Cog):
+    def __init__(self, bot: ButtercupBot, blossom_api: BlossomAPI) -> None:
+        """Initialize the Ping cog."""
+        self.bot = bot
+        self.blossom_api = blossom_api
+
+    @cog_ext.cog_slash(
+        name="ping", description="Ping the bot to find out if it is responsive.",
+    )
+    async def _ping(self, ctx: SlashContext) -> None:
+        """Ping the bot to find out if it is responsive."""
+        success_color = Color.green()
+        failure_color = Color.red()
+
+        embed = Embed(color=success_color, title="Pong!")
+
+        msg = await ctx.send(embed=embed)
+
+        # Also ping the blossom server
+        start = datetime.now()
+        response = self.blossom_api.get(path="ping/")
+        server_delay = datetime.now() - start
+        if response.status_code == 200:
+            embed.add_field(
+                name="Server", value=f"{server_delay.microseconds / 1000} ms"
+            )
+        else:
+            # For some reason, the color is read-only, so we need to make a new embed
+            embed = Embed(color=failure_color, title="Pong!")
+            embed.add_field(
+                name="Server", value=f"Error: Status code {response.status_code}"
+            )
+
+        await msg.edit(embed=embed)
+
+
+def setup(bot: ButtercupBot) -> None:
+    """Set up the Ping cog."""
+    cog_config = bot.config["Blossom"]
+    email = cog_config.get("email")
+    password = cog_config.get("password")
+    api_key = cog_config.get("api_key")
+    blossom_api = BlossomAPI(email=email, password=password, api_key=api_key)
+    bot.add_cog(Ping(bot=bot, blossom_api=blossom_api))
+
+
+def teardown(bot: ButtercupBot) -> None:
+    """Unload the Ping cog."""
+    bot.remove_cog("Ping")

--- a/buttercup/main.py
+++ b/buttercup/main.py
@@ -3,7 +3,7 @@ import sys
 from buttercup import logger
 from buttercup.bot import ButtercupBot
 
-EXTENSIONS = ["admin", "handlers", "name_validator", "find"]
+EXTENSIONS = ["admin", "handlers", "name_validator", "find", "ping"]
 
 
 logger.configure_logging()


### PR DESCRIPTION
Relevant issue: Closes #25.

## Description:

Adds a `/ping` command to determine if the bot is still responsive and if the server is online.
It also determines the latency of Blossom via the `/ping` endpoint.
Unfortuantely, I was unable to add the delay information for buttercup itself, as the slash command doesn't appear to provide timestamps.

## Screenshots:

![Example execution of the `/ping` command](https://user-images.githubusercontent.com/13908946/122252244-7ade3d00-cecb-11eb-908f-e5b45a47bbdf.png)

## Checklist:

- [x] Code Quality
- [x] Pep-8
- [ ] Tests (if applicable)
- [x] Success Criteria Met
- [x] Inline Documentation
- [ ] Wiki Documentation (if applicable)
