### PR TITLE
Add `/history` command

### DIFF
--- a/buttercup/cogs/__init__.py
+++ b/buttercup/cogs/__init__.py
@@ -18,3 +18,20 @@ plt.rcParams["ytick.color"] = line_color
 plt.rcParams["grid.color"] = line_color
 plt.rcParams["grid.alpha"] = 0.8
 plt.rcParams["figure.dpi"] = 200.0
+
+# Official flair ranks
+# Maybe we'll have this in the API one day,
+# but we need to define the colors client-side anyway
+ranks = {
+    "Initiate": {"threshold": 1, "color": "#ffffff"},
+    "Green": {"threshold": 50, "color": "#00ff00"},
+    "Teal": {"threshold": 100, "color": "#00cccc"},
+    "Purple": {"threshold": 250, "color": "#ff67ff"},
+    "Gold": {"threshold": 500, "color": "#ffd700"},
+    "Diamond": {"threshold": 1000, "color": "#add8e6"},
+    "Ruby": {"threshold": 2500, "color": "#ff7ac2"},
+    "Topaz": {"threshold": 5000, "color": "#ff7d4d"},
+    "Jade": {"threshold": 10000, "color": "#31c831"},
+    # This rank is not official yet, but we need it for predictions
+    "Sapphire": {"threshold": 25000, "color": "#99afef"},
+}

--- a/buttercup/cogs/__init__.py
+++ b/buttercup/cogs/__init__.py
@@ -22,16 +22,16 @@ plt.rcParams["figure.dpi"] = 200.0
 # Official flair ranks
 # Maybe we'll have this in the API one day,
 # but we need to define the colors client-side anyway
-ranks = {
-    "Initiate": {"threshold": 1, "color": "#ffffff"},
-    "Green": {"threshold": 50, "color": "#00ff00"},
-    "Teal": {"threshold": 100, "color": "#00cccc"},
-    "Purple": {"threshold": 250, "color": "#ff67ff"},
-    "Gold": {"threshold": 500, "color": "#ffd700"},
-    "Diamond": {"threshold": 1000, "color": "#add8e6"},
-    "Ruby": {"threshold": 2500, "color": "#ff7ac2"},
-    "Topaz": {"threshold": 5000, "color": "#ff7d4d"},
-    "Jade": {"threshold": 10000, "color": "#31c831"},
+ranks = [
+    {"name": "Initiate", "threshold": 1, "color": "#ffffff"},
+    {"name": "Green", "threshold": 50, "color": "#00ff00"},
+    {"name": "Teal", "threshold": 100, "color": "#00cccc"},
+    {"name": "Purple", "threshold": 250, "color": "#ff67ff"},
+    {"name": "Gold", "threshold": 500, "color": "#ffd700"},
+    {"name": "Diamond", "threshold": 1000, "color": "#add8e6"},
+    {"name": "Ruby", "threshold": 2500, "color": "#ff7ac2"},
+    {"name": "Topaz", "threshold": 5000, "color": "#ff7d4d"},
+    {"name": "Jade", "threshold": 10000, "color": "#31c831"},
     # This rank is not official yet, but we need it for predictions
-    "Sapphire": {"threshold": 25000, "color": "#99afef"},
-}
+    {"name": "Sapphire", "threshold": 25000, "color": "#99afef"},
+]

--- a/buttercup/cogs/handlers.py
+++ b/buttercup/cogs/handlers.py
@@ -5,7 +5,7 @@ from discord.ext import commands
 
 from buttercup import logger
 from buttercup.bot import ButtercupBot
-from buttercup.cogs.helpers import NoUsernameError
+from buttercup.cogs.helpers import BlossomException, NoUsernameException
 from buttercup.strings import translation
 
 i18n = translation()
@@ -30,13 +30,23 @@ class Handlers(commands.Cog):
         if isinstance(error, commands.CheckFailure):
             logger.warning("An unauthorized Command was performed.", ctx)
             await ctx.send(i18n["handlers"]["not_authorized"])
-        elif isinstance(error, NoUsernameError):
+        elif isinstance(error, NoUsernameException):
             logger.warning("Command executed without providing a username.", ctx)
             await ctx.send(i18n["handlers"]["no_username"])
+        elif isinstance(error, BlossomException):
+            tracker_id = uuid.uuid4()
+            logger.warning(
+                f"[{tracker_id}] Blossom Error: {error.status}\n{error.data}", ctx
+            )
+            await ctx.send(
+                i18n["handlers"]["blossom_error"].format(tracker_id=tracker_id)
+            )
         else:
             tracker_id = uuid.uuid4()
             logger.warning(f"[{tracker_id}] {type(error).__name__}: {str(error)}", ctx)
-            await ctx.send(i18n["handlers"]["unknown_error"].format(tracker_id))
+            await ctx.send(
+                i18n["handlers"]["unknown_error"].format(tracker_id=tracker_id)
+            )
 
 
 def setup(bot: ButtercupBot) -> None:

--- a/buttercup/cogs/helpers.py
+++ b/buttercup/cogs/helpers.py
@@ -48,10 +48,24 @@ def get_duration_str(start: datetime) -> str:
     return f"{duration_ms} ms"
 
 
-def get_progress_bar(count: int, total: int, width: int = 10) -> str:
+def get_progress_bar(
+    count: int,
+    total: int,
+    width: int = 10,
+    display_count: bool = False,
+    as_code: bool = True,
+) -> str:
     """Get a textual progress bar."""
     bar_count = round(count / total * width)
     inner_bar_count = min(bar_count, width)
     inner_space_count = width - inner_bar_count
     outer_bar_count = bar_count - inner_bar_count
-    return f"[{'#' * inner_bar_count}{' ' * inner_space_count}]{'#' * outer_bar_count}"
+
+    bar_str = (
+        f"[{'#' * inner_bar_count}{' ' * inner_space_count}]{'#' * outer_bar_count}"
+    )
+    if as_code:
+        bar_str = f"`{bar_str}`"
+    count_str = f" ({count:,d}/{total:,d})" if display_count else ""
+
+    return f"{bar_str}{count_str}"

--- a/buttercup/cogs/helpers.py
+++ b/buttercup/cogs/helpers.py
@@ -1,7 +1,6 @@
 import re
-from ctypes import Union
 from datetime import datetime
-from typing import List
+from typing import List, Union
 
 from blossom_wrapper import BlossomResponse
 from discord import DiscordException

--- a/buttercup/cogs/history.py
+++ b/buttercup/cogs/history.py
@@ -13,20 +13,11 @@ from discord_slash.utils.manage_commands import create_option
 from requests import HTTPError
 
 from buttercup.bot import ButtercupBot
+from buttercup.cogs.helpers import extract_username
 from buttercup.strings import translation
 
 
 i18n = translation()
-
-
-def username_from_display_name(display_name: str) -> Optional[str]:
-    """Extract the username from the display name."""
-    first_part = display_name.split(" ")[0]
-
-    if not first_part.startswith("/u/"):
-        return None
-
-    return first_part[3:]
 
 
 def create_file_from_data(
@@ -79,15 +70,7 @@ class History(Cog):
         page_size = 500
         msg = await ctx.send("Creating the history graph...")
 
-        username_1 = user_1
-        if user_1 is None:
-            username_1 = username_from_display_name(ctx.author.display_name)
-            if username_1 is None:
-                await msg.edit(
-                    content=f"{ctx.author.display_name} is an invalid username! "
-                    "Did you change your display name to the required format?"
-                )
-                return
+        username_1 = user_1 or extract_username(ctx.author.display_name)
 
         # First, get the total gamma for the user
         user_1_response = self.blossom_api.get_user(username_1)

--- a/buttercup/cogs/history.py
+++ b/buttercup/cogs/history.py
@@ -151,14 +151,6 @@ class History(Cog):
 
             # Continue with the next page
             page += 1
-            response = self.blossom_api.get(
-                f"volunteer/{user_id}/rate",
-                params={
-                    "page": page,
-                    "page_size": page_size,
-                    "time_frame": time_frame,
-                },
-            )
 
         user_data = add_zero_rates(user_data, time_frame)
 

--- a/buttercup/cogs/history.py
+++ b/buttercup/cogs/history.py
@@ -1,0 +1,79 @@
+from typing import Dict, Optional
+from urllib.parse import urlparse
+
+from blossom_wrapper import BlossomAPI, BlossomStatus
+from discord import Color, Embed
+from discord.ext.commands import Cog
+from discord_slash import SlashContext, cog_ext
+from discord_slash.utils.manage_commands import create_option
+
+from buttercup.bot import ButtercupBot
+from buttercup.strings import translation
+
+i18n = translation()
+
+
+def username_from_display_name(display_name: str) -> Optional[str]:
+    """Extract the username from the display name."""
+    first_part = display_name.split(" ")[0]
+
+    if not first_part.startswith("/u/"):
+        return None
+
+    return first_part[3:]
+
+
+class History(Cog):
+    def __init__(self, bot: ButtercupBot, blossom_api: BlossomAPI) -> None:
+        """Initialize the History cog."""
+        self.bot = bot
+        self.blossom_api = blossom_api
+
+    @cog_ext.cog_slash(
+        name="history",
+        description="Display the history graph.",
+        options=[
+            create_option(
+                name="user_1",
+                description="The user to display the history graph for.",
+                option_type=3,
+                required=False,
+            )
+        ],
+    )
+    async def _history(self, ctx: SlashContext, user_1: Optional[str] = None) -> None:
+        """Find the post with the given URL."""
+        # Give a quick response to let the user know we're working on it
+        # We'll later edit this message with the actual content
+        msg = await ctx.send("Creating the history graph...")
+
+        username_1 = user_1
+        if user_1 is None:
+            username_1 = username_from_display_name(ctx.author.display_name)
+            if username_1 is None:
+                await msg.edit(content=f"{ctx.author.display_name} is an invalid username! Did you change your display name to the required format?")
+                return
+
+        # First, get the total gamma for the user
+        user_1_response = self.blossom_api.get_user(username_1)
+        if user_1_response.status != BlossomStatus.ok:
+            await msg.edit(content=f"Failed to get the data for user {username_1}!")
+            return
+        user_1_gamma = user_1_response.data["gamma"]
+
+        await msg.edit(content=f"User {username_1} has {user_1_gamma} gamma.")
+
+
+def setup(bot: ButtercupBot) -> None:
+    """Set up the History cog."""
+    cog_config = bot.config["Blossom"]
+    email = cog_config.get("email")
+    password = cog_config.get("password")
+    api_key = cog_config.get("api_key")
+    blossom_api = BlossomAPI(email=email, password=password, api_key=api_key)
+    bot.add_cog(History(bot=bot, blossom_api=blossom_api))
+
+
+def teardown(bot: ButtercupBot) -> None:
+    """Unload the History cog."""
+    bot.remove_cog("History")

--- a/buttercup/cogs/history.py
+++ b/buttercup/cogs/history.py
@@ -1,5 +1,4 @@
 from typing import Dict, Optional
-from urllib.parse import urlparse
 
 from blossom_wrapper import BlossomAPI, BlossomStatus
 from discord import Color, Embed
@@ -9,6 +8,8 @@ from discord_slash.utils.manage_commands import create_option
 
 from buttercup.bot import ButtercupBot
 from buttercup.strings import translation
+
+import matplotlib.pyplot as plt
 
 i18n = translation()
 
@@ -66,11 +67,32 @@ class History(Cog):
 
 def setup(bot: ButtercupBot) -> None:
     """Set up the History cog."""
+    # Initialize blossom api
     cog_config = bot.config["Blossom"]
     email = cog_config.get("email")
     password = cog_config.get("password")
     api_key = cog_config.get("api_key")
     blossom_api = BlossomAPI(email=email, password=password, api_key=api_key)
+
+    # Initialize PyPlot
+
+    # Colors to use in the plots
+    background_color = "#36393f"  # Discord background color
+    text_color = "white"
+    line_color = "white"
+
+    # Global settings for the plots
+    plt.rcParams['figure.facecolor'] = background_color
+    plt.rcParams['axes.facecolor'] = background_color
+    plt.rcParams['axes.labelcolor'] = text_color
+    plt.rcParams['axes.edgecolor'] = line_color
+    plt.rcParams['text.color'] = text_color
+    plt.rcParams['xtick.color'] = line_color
+    plt.rcParams['ytick.color'] = line_color
+    plt.rcParams['grid.color'] = line_color
+    plt.rcParams['grid.alpha'] = 0.8
+    plt.rcParams["figure.dpi"] = 200.0
+
     bot.add_cog(History(bot=bot, blossom_api=blossom_api))
 
 

--- a/buttercup/cogs/history.py
+++ b/buttercup/cogs/history.py
@@ -13,7 +13,7 @@ from discord_slash.utils.manage_commands import create_option
 from requests import HTTPError
 
 from buttercup.bot import ButtercupBot
-from buttercup.cogs.helpers import extract_username
+from buttercup.cogs.helpers import extract_username, get_progress_bar, get_duration_str
 from buttercup.strings import translation
 
 
@@ -35,13 +35,6 @@ def create_file_from_data(
     plt.clf()
 
     return File(history_plot, "history_plot.png")
-
-
-def get_progress_indicator(current: int, maximum: int) -> str:
-    """Get a string indicating the current progress."""
-    max_bars = 20
-    bars = math.ceil((current / maximum) * max_bars)
-    return f"`[{bars * '#'}{(max_bars - bars) * ' '}]` ({current}/{maximum})"
 
 
 class History(Cog):
@@ -82,7 +75,7 @@ class History(Cog):
 
         await msg.edit(
             content=f"Creating the history graph... "
-            f"{get_progress_indicator(0, user_1_gamma)}"
+            f"{get_progress_bar(0, user_1_gamma, display_count=True)}"
         )
 
         user_1_times = [datetime.now()]
@@ -105,7 +98,7 @@ class History(Cog):
 
             await msg.edit(
                 content=f"Creating the history graph... "
-                f"{get_progress_indicator(gamma_offset, user_1_gamma)}"
+                f"{get_progress_bar(gamma_offset, user_1_gamma, display_count=True)}"
             )
 
             # Continue with the next page
@@ -119,9 +112,8 @@ class History(Cog):
                 discord_file = create_file_from_data(
                     user_1_times, user_1_values, user_1
                 )
-                duration = datetime.now() - start
                 await msg.edit(
-                    content=f"I created the plot in {duration.seconds}s",
+                    content=f"Here is your history graph! ({get_duration_str(start)})",
                     file=discord_file,
                 )
                 break
@@ -135,26 +127,6 @@ def setup(bot: ButtercupBot) -> None:
     password = cog_config.get("password")
     api_key = cog_config.get("api_key")
     blossom_api = BlossomAPI(email=email, password=password, api_key=api_key)
-
-    # Initialize PyPlot
-
-    # Colors to use in the plots
-    background_color = "#36393f"  # Discord background color
-    text_color = "white"
-    line_color = "white"
-
-    # Global settings for the plots
-    plt.rcParams["figure.facecolor"] = background_color
-    plt.rcParams["axes.facecolor"] = background_color
-    plt.rcParams["axes.labelcolor"] = text_color
-    plt.rcParams["axes.edgecolor"] = line_color
-    plt.rcParams["text.color"] = text_color
-    plt.rcParams["xtick.color"] = line_color
-    plt.rcParams["ytick.color"] = line_color
-    plt.rcParams["grid.color"] = line_color
-    plt.rcParams["grid.alpha"] = 0.8
-    plt.rcParams["figure.dpi"] = 200.0
-
     bot.add_cog(History(bot=bot, blossom_api=blossom_api))
 
 

--- a/buttercup/cogs/history.py
+++ b/buttercup/cogs/history.py
@@ -86,8 +86,7 @@ def add_rank_lines(ax: plt.Axes, gamma: int) -> plt.Axes:
     """Add the rank lines to the given axes."""
     # Show ranks when you are close to them already
     threshold_factor = 0.7
-    for rank_name in ranks:
-        rank = ranks[rank_name]
+    for rank in ranks:
         if gamma >= rank["threshold"] * threshold_factor:
             ax.axhline(y=rank["threshold"], color=rank["color"], zorder=-1)
     return ax
@@ -172,7 +171,7 @@ class History(Cog):
 
         for label in ax.get_xticklabels():
             label.set_rotation(15)
-            label.set_ha('right')
+            label.set_ha("right")
 
         if len(users) == 1:
             ax.set_title(i18n["history"]["plot_title_single"].format(user=username_1))
@@ -235,11 +234,12 @@ class History(Cog):
                 # Aggregate the gamma score
                 user_data = user_data.assign(gamma=user_data.expanding(1).sum())
                 # Plot the graph
-                ax.plot("date", "gamma", data=user_data.reset_index(), color="white")
+                ax.plot("date", "gamma", data=user_data.reset_index(), color=ranks[index]["color"])
             else:
                 raise BlossomException(response)
 
         add_rank_lines(ax, max(user_gammas))
+        ax.legend([f"u/{user}" for user in users])
 
         discord_file = create_file_from_figure(fig, "history_plot.png")
 

--- a/buttercup/cogs/history.py
+++ b/buttercup/cogs/history.py
@@ -76,6 +76,8 @@ class History(Cog):
         """Find the post with the given URL."""
         # Give a quick response to let the user know we're working on it
         # We'll later edit this message with the actual content
+        start = datetime.now()
+        page_size = 500
         msg = await ctx.send("Creating the history graph...")
 
         username_1 = user_1
@@ -105,11 +107,10 @@ class History(Cog):
         user_1_values = [user_1_gamma]
         page = 1
         gamma_offset = 0
-        response = self.blossom_api.get_transcription(author=user_1_id, page=page)
+        response = self.blossom_api.get_transcription(author=user_1_id, page=page, page_size=page_size)
 
         while response.status == BlossomStatus.ok:
             transcriptions = response.data
-            logging.info(f"Transcriptions: {len(transcriptions)}")
 
             # Add the transcriptions to the data
             for tr in transcriptions:
@@ -127,15 +128,15 @@ class History(Cog):
             page += 1
             try:
                 response = self.blossom_api.get_transcription(
-                    author=user_1_id, page=page
+                    author=user_1_id, page=page, page_size=page_size
                 )
             except HTTPError:
                 # Hack: The next page is not available anymore, so we reached the end
                 discord_file = create_file_from_data(
                     user_1_times, user_1_values, user_1
                 )
-
-                await msg.edit(content="Here is the plot!", file=discord_file)
+                duration = datetime.now() - start
+                await msg.edit(content=f"I created the plot in {duration.seconds}s", file=discord_file)
                 break
 
 

--- a/buttercup/main.py
+++ b/buttercup/main.py
@@ -19,4 +19,4 @@ EXTENSIONS = [
 logger.configure_logging()
 config_path = sys.argv[1] if len(sys.argv) > 1 else "config.toml"
 bot = ButtercupBot(command_prefix="!", config_path=config_path, extensions=EXTENSIONS)
-bot.run(bot.config["secrets"]["discord"])
+bot.run(bot.config["Discord"]["token"])

--- a/buttercup/main.py
+++ b/buttercup/main.py
@@ -3,7 +3,7 @@ import sys
 from buttercup import logger
 from buttercup.bot import ButtercupBot
 
-EXTENSIONS = ["admin", "handlers", "name_validator", "find"]
+EXTENSIONS = ["admin", "handlers", "name_validator", "find", "history"]
 
 
 logger.configure_logging()

--- a/buttercup/strings/en_US.yaml
+++ b/buttercup/strings/en_US.yaml
@@ -3,8 +3,10 @@ handlers:
     You are not authorized to use this command. This incident will be reported.
   no_username: |
     You did not provide a valid username. Either add it to the command or change your display name to a valid format.
+  blossom_error: |
+    [{tracker_id}] An error occurred while accessing the Blossom API. Please contact a moderator with the provided ID.
   unknown_error: |
-    [{0}] Something went wrong, please contact a moderator with the provided ID.
+    [{tracker_id}] Something went wrong, please contact a moderator with the provided ID.
 name_validator:
   new_member: |
     Hello, <@{0}>! Welcome to the Transcribers of Reddit chill room! Thanks for helping make somebody's day better!
@@ -138,12 +140,9 @@ heatmap:
     - Fri
     - Sat
     - Sun
-  plot_title: |
-    Activity Heatmap for u/{0}
-  plot_xlabel: |
-    Time ({0})
-  plot_ylabel: |
-    Weekday
+  plot_title: Activity Heatmap for u/{0}
+  plot_xlabel: Time ({0})
+  plot_ylabel: Weekday
   response_message: |
     Here is the heatmap for u/{0}! ({1})
 rules:
@@ -177,3 +176,14 @@ pi_rules:
     I automatically detected some rules regarding personal information! ({0})
   embed_title: |
     PI Rules for r/{0}
+history:
+    getting_history_single: |
+      Creating the history graph for u/{user}...
+    getting_history_multi: |
+      Creating the history graph for {users} ({count}/{total})...
+    plot_title_single: History of u/{user}
+    plot_title_multi: History of Multiple Users
+    plot_xlabel: Time
+    plot_ylabel: Gamma
+    response_message:
+      Here is the history graph! ({duration})

--- a/poetry.lock
+++ b/poetry.lock
@@ -156,6 +156,17 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
+name = "cycler"
+version = "0.10.0"
+description = "Composable style cycles"
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+six = "*"
+
+[[package]]
 name = "discord-py-slash-command"
 version = "1.2.2"
 description = "A simple discord slash command handler for discord.py."
@@ -306,6 +317,30 @@ requirements = ["pipreqs", "pip-api"]
 xdg_home = ["appdirs (>=1.4.0)"]
 
 [[package]]
+name = "kiwisolver"
+version = "1.3.1"
+description = "A fast implementation of the Cassowary constraint solver"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[[package]]
+name = "matplotlib"
+version = "3.4.2"
+description = "Python plotting package"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+cycler = ">=0.10"
+kiwisolver = ">=1.0.1"
+numpy = ">=1.16"
+pillow = ">=6.2.0"
+pyparsing = ">=2.2.1"
+python-dateutil = ">=2.7"
+
+[[package]]
 name = "mccabe"
 version = "0.6.1"
 description = "McCabe checker, plugin for flake8"
@@ -330,6 +365,14 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "numpy"
+version = "1.20.3"
+description = "NumPy is the fundamental package for array computing with Python."
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[[package]]
 name = "pathspec"
 version = "0.8.1"
 description = "Utility library for gitignore style pattern matching of file paths."
@@ -347,6 +390,14 @@ python-versions = "*"
 
 [package.dependencies]
 flake8-polyfill = ">=1.0.2,<2"
+
+[[package]]
+name = "pillow"
+version = "8.2.0"
+description = "Python Imaging Library (Fork)"
+category = "main"
+optional = false
+python-versions = ">=3.6"
 
 [[package]]
 name = "pre-commit"
@@ -393,6 +444,14 @@ description = "passive checker of Python programs"
 category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[[package]]
+name = "pyparsing"
+version = "2.4.7"
+description = "Python parsing module"
+category = "main"
+optional = false
+python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
 name = "python-dateutil"
@@ -536,7 +595,7 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "fa129ee58b02d7a756ae0928c83fb09d6bb4b38686f5fa5c53bd1d79c67ec80d"
+content-hash = "cbf3854e9776fb65c59ec70ccdf2bd72b0ca3dafae7e3b2cca38ab690e4219c0"
 
 [metadata.files]
 aiohttp = [
@@ -627,6 +686,10 @@ colorama = [
     {file = "colorama-0.4.4-py2.py3-none-any.whl", hash = "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"},
     {file = "colorama-0.4.4.tar.gz", hash = "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b"},
 ]
+cycler = [
+    {file = "cycler-0.10.0-py2.py3-none-any.whl", hash = "sha256:1d8a5ae1ff6c5cf9b93e8811e581232ad8920aeec647c37316ceac982b08cb2d"},
+    {file = "cycler-0.10.0.tar.gz", hash = "sha256:cd7b2d1018258d7247a71425e9f26463dfb444d411c39569972f4ce586b0c9d8"},
+]
 discord-py-slash-command = [
     {file = "discord-py-slash-command-1.2.2.tar.gz", hash = "sha256:192b4454bb5ca9e6032812a4142469782ab7a8a4f93c13fb04bb5a2ff100ddfb"},
     {file = "discord_py_slash_command-1.2.2-py3-none-any.whl", hash = "sha256:5539b931af40b3bc91ee0a8ed1e97a58400c442ef542007db9dda315dce90144"},
@@ -681,6 +744,61 @@ isort = [
     {file = "isort-4.3.21-py2.py3-none-any.whl", hash = "sha256:6e811fcb295968434526407adb8796944f1988c5b65e8139058f2014cbe100fd"},
     {file = "isort-4.3.21.tar.gz", hash = "sha256:54da7e92468955c4fceacd0c86bd0ec997b0e1ee80d97f67c35a78b719dccab1"},
 ]
+kiwisolver = [
+    {file = "kiwisolver-1.3.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:fd34fbbfbc40628200730bc1febe30631347103fc8d3d4fa012c21ab9c11eca9"},
+    {file = "kiwisolver-1.3.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:d3155d828dec1d43283bd24d3d3e0d9c7c350cdfcc0bd06c0ad1209c1bbc36d0"},
+    {file = "kiwisolver-1.3.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:5a7a7dbff17e66fac9142ae2ecafb719393aaee6a3768c9de2fd425c63b53e21"},
+    {file = "kiwisolver-1.3.1-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:f8d6f8db88049a699817fd9178782867bf22283e3813064302ac59f61d95be05"},
+    {file = "kiwisolver-1.3.1-cp36-cp36m-manylinux2014_ppc64le.whl", hash = "sha256:5f6ccd3dd0b9739edcf407514016108e2280769c73a85b9e59aa390046dbf08b"},
+    {file = "kiwisolver-1.3.1-cp36-cp36m-win32.whl", hash = "sha256:225e2e18f271e0ed8157d7f4518ffbf99b9450fca398d561eb5c4a87d0986dd9"},
+    {file = "kiwisolver-1.3.1-cp36-cp36m-win_amd64.whl", hash = "sha256:cf8b574c7b9aa060c62116d4181f3a1a4e821b2ec5cbfe3775809474113748d4"},
+    {file = "kiwisolver-1.3.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:232c9e11fd7ac3a470d65cd67e4359eee155ec57e822e5220322d7b2ac84fbf0"},
+    {file = "kiwisolver-1.3.1-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:b38694dcdac990a743aa654037ff1188c7a9801ac3ccc548d3341014bc5ca278"},
+    {file = "kiwisolver-1.3.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:ca3820eb7f7faf7f0aa88de0e54681bddcb46e485beb844fcecbcd1c8bd01689"},
+    {file = "kiwisolver-1.3.1-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:c8fd0f1ae9d92b42854b2979024d7597685ce4ada367172ed7c09edf2cef9cb8"},
+    {file = "kiwisolver-1.3.1-cp37-cp37m-manylinux2014_ppc64le.whl", hash = "sha256:1e1bc12fb773a7b2ffdeb8380609f4f8064777877b2225dec3da711b421fda31"},
+    {file = "kiwisolver-1.3.1-cp37-cp37m-win32.whl", hash = "sha256:72c99e39d005b793fb7d3d4e660aed6b6281b502e8c1eaf8ee8346023c8e03bc"},
+    {file = "kiwisolver-1.3.1-cp37-cp37m-win_amd64.whl", hash = "sha256:8be8d84b7d4f2ba4ffff3665bcd0211318aa632395a1a41553250484a871d454"},
+    {file = "kiwisolver-1.3.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:31dfd2ac56edc0ff9ac295193eeaea1c0c923c0355bf948fbd99ed6018010b72"},
+    {file = "kiwisolver-1.3.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:563c649cfdef27d081c84e72a03b48ea9408c16657500c312575ae9d9f7bc1c3"},
+    {file = "kiwisolver-1.3.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:78751b33595f7f9511952e7e60ce858c6d64db2e062afb325985ddbd34b5c131"},
+    {file = "kiwisolver-1.3.1-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:a357fd4f15ee49b4a98b44ec23a34a95f1e00292a139d6015c11f55774ef10de"},
+    {file = "kiwisolver-1.3.1-cp38-cp38-manylinux2014_ppc64le.whl", hash = "sha256:5989db3b3b34b76c09253deeaf7fbc2707616f130e166996606c284395da3f18"},
+    {file = "kiwisolver-1.3.1-cp38-cp38-win32.whl", hash = "sha256:c08e95114951dc2090c4a630c2385bef681cacf12636fb0241accdc6b303fd81"},
+    {file = "kiwisolver-1.3.1-cp38-cp38-win_amd64.whl", hash = "sha256:44a62e24d9b01ba94ae7a4a6c3fb215dc4af1dde817e7498d901e229aaf50e4e"},
+    {file = "kiwisolver-1.3.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:50af681a36b2a1dee1d3c169ade9fdc59207d3c31e522519181e12f1b3ba7000"},
+    {file = "kiwisolver-1.3.1-cp39-cp39-manylinux1_i686.whl", hash = "sha256:a53d27d0c2a0ebd07e395e56a1fbdf75ffedc4a05943daf472af163413ce9598"},
+    {file = "kiwisolver-1.3.1-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:834ee27348c4aefc20b479335fd422a2c69db55f7d9ab61721ac8cd83eb78882"},
+    {file = "kiwisolver-1.3.1-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:5c3e6455341008a054cccee8c5d24481bcfe1acdbc9add30aa95798e95c65621"},
+    {file = "kiwisolver-1.3.1-cp39-cp39-manylinux2014_ppc64le.whl", hash = "sha256:acef3d59d47dd85ecf909c359d0fd2c81ed33bdff70216d3956b463e12c38a54"},
+    {file = "kiwisolver-1.3.1-cp39-cp39-win32.whl", hash = "sha256:c5518d51a0735b1e6cee1fdce66359f8d2b59c3ca85dc2b0813a8aa86818a030"},
+    {file = "kiwisolver-1.3.1-cp39-cp39-win_amd64.whl", hash = "sha256:b9edd0110a77fc321ab090aaa1cfcaba1d8499850a12848b81be2222eab648f6"},
+    {file = "kiwisolver-1.3.1-pp36-pypy36_pp73-macosx_10_9_x86_64.whl", hash = "sha256:0cd53f403202159b44528498de18f9285b04482bab2a6fc3f5dd8dbb9352e30d"},
+    {file = "kiwisolver-1.3.1-pp36-pypy36_pp73-manylinux2010_x86_64.whl", hash = "sha256:33449715e0101e4d34f64990352bce4095c8bf13bed1b390773fc0a7295967b3"},
+    {file = "kiwisolver-1.3.1-pp36-pypy36_pp73-win32.whl", hash = "sha256:401a2e9afa8588589775fe34fc22d918ae839aaaf0c0e96441c0fdbce6d8ebe6"},
+    {file = "kiwisolver-1.3.1.tar.gz", hash = "sha256:950a199911a8d94683a6b10321f9345d5a3a8433ec58b217ace979e18f16e248"},
+]
+matplotlib = [
+    {file = "matplotlib-3.4.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:c541ee5a3287efe066bbe358320853cf4916bc14c00c38f8f3d8d75275a405a9"},
+    {file = "matplotlib-3.4.2-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:3a5c18dbd2c7c366da26a4ad1462fe3e03a577b39e3b503bbcf482b9cdac093c"},
+    {file = "matplotlib-3.4.2-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:a9d8cb5329df13e0cdaa14b3b43f47b5e593ec637f13f14db75bb16e46178b05"},
+    {file = "matplotlib-3.4.2-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:7ad19f3fb6145b9eb41c08e7cbb9f8e10b91291396bee21e9ce761bb78df63ec"},
+    {file = "matplotlib-3.4.2-cp37-cp37m-win32.whl", hash = "sha256:7a58f3d8fe8fac3be522c79d921c9b86e090a59637cb88e3bc51298d7a2c862a"},
+    {file = "matplotlib-3.4.2-cp37-cp37m-win_amd64.whl", hash = "sha256:6382bc6e2d7e481bcd977eb131c31dee96e0fb4f9177d15ec6fb976d3b9ace1a"},
+    {file = "matplotlib-3.4.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:6a6a44f27aabe720ec4fd485061e8a35784c2b9ffa6363ad546316dfc9cea04e"},
+    {file = "matplotlib-3.4.2-cp38-cp38-manylinux1_i686.whl", hash = "sha256:1c1779f7ab7d8bdb7d4c605e6ffaa0614b3e80f1e3c8ccf7b9269a22dbc5986b"},
+    {file = "matplotlib-3.4.2-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:5826f56055b9b1c80fef82e326097e34dc4af8c7249226b7dd63095a686177d1"},
+    {file = "matplotlib-3.4.2-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:0bea5ec5c28d49020e5d7923c2725b837e60bc8be99d3164af410eb4b4c827da"},
+    {file = "matplotlib-3.4.2-cp38-cp38-win32.whl", hash = "sha256:6475d0209024a77f869163ec3657c47fed35d9b6ed8bccba8aa0f0099fbbdaa8"},
+    {file = "matplotlib-3.4.2-cp38-cp38-win_amd64.whl", hash = "sha256:21b31057bbc5e75b08e70a43cefc4c0b2c2f1b1a850f4a0f7af044eb4163086c"},
+    {file = "matplotlib-3.4.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:b26535b9de85326e6958cdef720ecd10bcf74a3f4371bf9a7e5b2e659c17e153"},
+    {file = "matplotlib-3.4.2-cp39-cp39-manylinux1_i686.whl", hash = "sha256:32fa638cc10886885d1ca3d409d4473d6a22f7ceecd11322150961a70fab66dd"},
+    {file = "matplotlib-3.4.2-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:956c8849b134b4a343598305a3ca1bdd3094f01f5efc8afccdebeffe6b315247"},
+    {file = "matplotlib-3.4.2-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:85f191bb03cb1a7b04b5c2cca4792bef94df06ef473bc49e2818105671766fee"},
+    {file = "matplotlib-3.4.2-cp39-cp39-win32.whl", hash = "sha256:b1d5a2cedf5de05567c441b3a8c2651fbde56df08b82640e7f06c8cd91e201f6"},
+    {file = "matplotlib-3.4.2-cp39-cp39-win_amd64.whl", hash = "sha256:df815378a754a7edd4559f8c51fc7064f779a74013644a7f5ac7a0c31f875866"},
+    {file = "matplotlib-3.4.2.tar.gz", hash = "sha256:d8d994cefdff9aaba45166eb3de4f5211adb4accac85cbf97137e98f26ea0219"},
+]
 mccabe = [
     {file = "mccabe-0.6.1-py2.py3-none-any.whl", hash = "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42"},
     {file = "mccabe-0.6.1.tar.gz", hash = "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"},
@@ -728,6 +846,32 @@ nodeenv = [
     {file = "nodeenv-1.6.0-py2.py3-none-any.whl", hash = "sha256:621e6b7076565ddcacd2db0294c0381e01fd28945ab36bcf00f41c5daf63bef7"},
     {file = "nodeenv-1.6.0.tar.gz", hash = "sha256:3ef13ff90291ba2a4a7a4ff9a979b63ffdd00a464dbe04acf0ea6471517a4c2b"},
 ]
+numpy = [
+    {file = "numpy-1.20.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:70eb5808127284c4e5c9e836208e09d685a7978b6a216db85960b1a112eeace8"},
+    {file = "numpy-1.20.3-cp37-cp37m-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:6ca2b85a5997dabc38301a22ee43c82adcb53ff660b89ee88dded6b33687e1d8"},
+    {file = "numpy-1.20.3-cp37-cp37m-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:c5bf0e132acf7557fc9bb8ded8b53bbbbea8892f3c9a1738205878ca9434206a"},
+    {file = "numpy-1.20.3-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:db250fd3e90117e0312b611574cd1b3f78bec046783195075cbd7ba9c3d73f16"},
+    {file = "numpy-1.20.3-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:637d827248f447e63585ca3f4a7d2dfaa882e094df6cfa177cc9cf9cd6cdf6d2"},
+    {file = "numpy-1.20.3-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:8b7bb4b9280da3b2856cb1fc425932f46fba609819ee1c62256f61799e6a51d2"},
+    {file = "numpy-1.20.3-cp37-cp37m-win32.whl", hash = "sha256:67d44acb72c31a97a3d5d33d103ab06d8ac20770e1c5ad81bdb3f0c086a56cf6"},
+    {file = "numpy-1.20.3-cp37-cp37m-win_amd64.whl", hash = "sha256:43909c8bb289c382170e0282158a38cf306a8ad2ff6dfadc447e90f9961bef43"},
+    {file = "numpy-1.20.3-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:f1452578d0516283c87608a5a5548b0cdde15b99650efdfd85182102ef7a7c17"},
+    {file = "numpy-1.20.3-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:6e51534e78d14b4a009a062641f465cfaba4fdcb046c3ac0b1f61dd97c861b1b"},
+    {file = "numpy-1.20.3-cp38-cp38-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:e515c9a93aebe27166ec9593411c58494fa98e5fcc219e47260d9ab8a1cc7f9f"},
+    {file = "numpy-1.20.3-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c1c09247ccea742525bdb5f4b5ceeacb34f95731647fe55774aa36557dbb5fa4"},
+    {file = "numpy-1.20.3-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:66fbc6fed94a13b9801fb70b96ff30605ab0a123e775a5e7a26938b717c5d71a"},
+    {file = "numpy-1.20.3-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:ea9cff01e75a956dbee133fa8e5b68f2f92175233de2f88de3a682dd94deda65"},
+    {file = "numpy-1.20.3-cp38-cp38-win32.whl", hash = "sha256:f39a995e47cb8649673cfa0579fbdd1cdd33ea497d1728a6cb194d6252268e48"},
+    {file = "numpy-1.20.3-cp38-cp38-win_amd64.whl", hash = "sha256:1676b0a292dd3c99e49305a16d7a9f42a4ab60ec522eac0d3dd20cdf362ac010"},
+    {file = "numpy-1.20.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:830b044f4e64a76ba71448fce6e604c0fc47a0e54d8f6467be23749ac2cbd2fb"},
+    {file = "numpy-1.20.3-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:55b745fca0a5ab738647d0e4db099bd0a23279c32b31a783ad2ccea729e632df"},
+    {file = "numpy-1.20.3-cp39-cp39-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:5d050e1e4bc9ddb8656d7b4f414557720ddcca23a5b88dd7cff65e847864c400"},
+    {file = "numpy-1.20.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a9c65473ebc342715cb2d7926ff1e202c26376c0dcaaee85a1fd4b8d8c1d3b2f"},
+    {file = "numpy-1.20.3-cp39-cp39-win32.whl", hash = "sha256:16f221035e8bd19b9dc9a57159e38d2dd060b48e93e1d843c49cb370b0f415fd"},
+    {file = "numpy-1.20.3-cp39-cp39-win_amd64.whl", hash = "sha256:6690080810f77485667bfbff4f69d717c3be25e5b11bb2073e76bb3f578d99b4"},
+    {file = "numpy-1.20.3-pp37-pypy37_pp73-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:4e465afc3b96dbc80cf4a5273e5e2b1e3451286361b4af70ce1adb2984d392f9"},
+    {file = "numpy-1.20.3.zip", hash = "sha256:e55185e51b18d788e49fe8305fd73ef4470596b33fc2c1ceb304566b99c71a69"},
+]
 pathspec = [
     {file = "pathspec-0.8.1-py2.py3-none-any.whl", hash = "sha256:aa0cb481c4041bf52ffa7b0d8fa6cd3e88a2ca4879c533c9153882ee2556790d"},
     {file = "pathspec-0.8.1.tar.gz", hash = "sha256:86379d6b86d75816baba717e64b1a3a3469deb93bb76d613c9ce79edc5cb68fd"},
@@ -735,6 +879,42 @@ pathspec = [
 pep8-naming = [
     {file = "pep8-naming-0.9.1.tar.gz", hash = "sha256:a33d38177056321a167decd6ba70b890856ba5025f0a8eca6a3eda607da93caf"},
     {file = "pep8_naming-0.9.1-py2.py3-none-any.whl", hash = "sha256:45f330db8fcfb0fba57458c77385e288e7a3be1d01e8ea4268263ef677ceea5f"},
+]
+pillow = [
+    {file = "Pillow-8.2.0-cp36-cp36m-macosx_10_10_x86_64.whl", hash = "sha256:dc38f57d8f20f06dd7c3161c59ca2c86893632623f33a42d592f097b00f720a9"},
+    {file = "Pillow-8.2.0-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:a013cbe25d20c2e0c4e85a9daf438f85121a4d0344ddc76e33fd7e3965d9af4b"},
+    {file = "Pillow-8.2.0-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:8bb1e155a74e1bfbacd84555ea62fa21c58e0b4e7e6b20e4447b8d07990ac78b"},
+    {file = "Pillow-8.2.0-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:c5236606e8570542ed424849f7852a0ff0bce2c4c8d0ba05cc202a5a9c97dee9"},
+    {file = "Pillow-8.2.0-cp36-cp36m-win32.whl", hash = "sha256:12e5e7471f9b637762453da74e390e56cc43e486a88289995c1f4c1dc0bfe727"},
+    {file = "Pillow-8.2.0-cp36-cp36m-win_amd64.whl", hash = "sha256:5afe6b237a0b81bd54b53f835a153770802f164c5570bab5e005aad693dab87f"},
+    {file = "Pillow-8.2.0-cp37-cp37m-macosx_10_10_x86_64.whl", hash = "sha256:cb7a09e173903541fa888ba010c345893cd9fc1b5891aaf060f6ca77b6a3722d"},
+    {file = "Pillow-8.2.0-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:0d19d70ee7c2ba97631bae1e7d4725cdb2ecf238178096e8c82ee481e189168a"},
+    {file = "Pillow-8.2.0-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:083781abd261bdabf090ad07bb69f8f5599943ddb539d64497ed021b2a67e5a9"},
+    {file = "Pillow-8.2.0-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:c6b39294464b03457f9064e98c124e09008b35a62e3189d3513e5148611c9388"},
+    {file = "Pillow-8.2.0-cp37-cp37m-win32.whl", hash = "sha256:01425106e4e8cee195a411f729cff2a7d61813b0b11737c12bd5991f5f14bcd5"},
+    {file = "Pillow-8.2.0-cp37-cp37m-win_amd64.whl", hash = "sha256:3b570f84a6161cf8865c4e08adf629441f56e32f180f7aa4ccbd2e0a5a02cba2"},
+    {file = "Pillow-8.2.0-cp38-cp38-macosx_10_10_x86_64.whl", hash = "sha256:031a6c88c77d08aab84fecc05c3cde8414cd6f8406f4d2b16fed1e97634cc8a4"},
+    {file = "Pillow-8.2.0-cp38-cp38-manylinux1_i686.whl", hash = "sha256:66cc56579fd91f517290ab02c51e3a80f581aba45fd924fcdee01fa06e635812"},
+    {file = "Pillow-8.2.0-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:6c32cc3145928c4305d142ebec682419a6c0a8ce9e33db900027ddca1ec39178"},
+    {file = "Pillow-8.2.0-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:624b977355cde8b065f6d51b98497d6cd5fbdd4f36405f7a8790e3376125e2bb"},
+    {file = "Pillow-8.2.0-cp38-cp38-win32.whl", hash = "sha256:5cbf3e3b1014dddc45496e8cf38b9f099c95a326275885199f427825c6522232"},
+    {file = "Pillow-8.2.0-cp38-cp38-win_amd64.whl", hash = "sha256:463822e2f0d81459e113372a168f2ff59723e78528f91f0bd25680ac185cf797"},
+    {file = "Pillow-8.2.0-cp39-cp39-macosx_10_10_x86_64.whl", hash = "sha256:95d5ef984eff897850f3a83883363da64aae1000e79cb3c321915468e8c6add5"},
+    {file = "Pillow-8.2.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:b91c36492a4bbb1ee855b7d16fe51379e5f96b85692dc8210831fbb24c43e484"},
+    {file = "Pillow-8.2.0-cp39-cp39-manylinux1_i686.whl", hash = "sha256:d68cb92c408261f806b15923834203f024110a2e2872ecb0bd2a110f89d3c602"},
+    {file = "Pillow-8.2.0-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:f217c3954ce5fd88303fc0c317af55d5e0204106d86dea17eb8205700d47dec2"},
+    {file = "Pillow-8.2.0-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:5b70110acb39f3aff6b74cf09bb4169b167e2660dabc304c1e25b6555fa781ef"},
+    {file = "Pillow-8.2.0-cp39-cp39-win32.whl", hash = "sha256:a7d5e9fad90eff8f6f6106d3b98b553a88b6f976e51fce287192a5d2d5363713"},
+    {file = "Pillow-8.2.0-cp39-cp39-win_amd64.whl", hash = "sha256:238c197fc275b475e87c1453b05b467d2d02c2915fdfdd4af126145ff2e4610c"},
+    {file = "Pillow-8.2.0-pp36-pypy36_pp73-macosx_10_10_x86_64.whl", hash = "sha256:0e04d61f0064b545b989126197930807c86bcbd4534d39168f4aa5fda39bb8f9"},
+    {file = "Pillow-8.2.0-pp36-pypy36_pp73-manylinux2010_i686.whl", hash = "sha256:63728564c1410d99e6d1ae8e3b810fe012bc440952168af0a2877e8ff5ab96b9"},
+    {file = "Pillow-8.2.0-pp36-pypy36_pp73-manylinux2010_x86_64.whl", hash = "sha256:c03c07ed32c5324939b19e36ae5f75c660c81461e312a41aea30acdd46f93a7c"},
+    {file = "Pillow-8.2.0-pp37-pypy37_pp73-macosx_10_10_x86_64.whl", hash = "sha256:4d98abdd6b1e3bf1a1cbb14c3895226816e666749ac040c4e2554231068c639b"},
+    {file = "Pillow-8.2.0-pp37-pypy37_pp73-manylinux2010_i686.whl", hash = "sha256:aac00e4bc94d1b7813fe882c28990c1bc2f9d0e1aa765a5f2b516e8a6a16a9e4"},
+    {file = "Pillow-8.2.0-pp37-pypy37_pp73-manylinux2010_x86_64.whl", hash = "sha256:22fd0f42ad15dfdde6c581347eaa4adb9a6fc4b865f90b23378aa7914895e120"},
+    {file = "Pillow-8.2.0-pp37-pypy37_pp73-win32.whl", hash = "sha256:e98eca29a05913e82177b3ba3d198b1728e164869c613d76d0de4bde6768a50e"},
+    {file = "Pillow-8.2.0-pp37-pypy37_pp73-win_amd64.whl", hash = "sha256:8b56553c0345ad6dcb2e9b433ae47d67f95fc23fe28a0bde15a120f25257e291"},
+    {file = "Pillow-8.2.0.tar.gz", hash = "sha256:a787ab10d7bb5494e5f76536ac460741788f1fbce851068d73a87ca7c35fc3e1"},
 ]
 pre-commit = [
     {file = "pre_commit-2.13.0-py2.py3-none-any.whl", hash = "sha256:b679d0fddd5b9d6d98783ae5f10fd0c4c59954f375b70a58cbe1ce9bcf9809a4"},
@@ -751,6 +931,10 @@ pydocstyle = [
 pyflakes = [
     {file = "pyflakes-2.3.1-py2.py3-none-any.whl", hash = "sha256:7893783d01b8a89811dd72d7dfd4d84ff098e5eed95cfa8905b22bbffe52efc3"},
     {file = "pyflakes-2.3.1.tar.gz", hash = "sha256:f5bc8ecabc05bb9d291eb5203d6810b49040f6ff446a756326104746cc00c1db"},
+]
+pyparsing = [
+    {file = "pyparsing-2.4.7-py2.py3-none-any.whl", hash = "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"},
+    {file = "pyparsing-2.4.7.tar.gz", hash = "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1"},
 ]
 python-dateutil = [
     {file = "python-dateutil-2.8.1.tar.gz", hash = "sha256:73ebfe9dbf22e832286dafa60473e4cd239f8592f699aa5adaf10050e6e1823c"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ blossom-wrapper = { git = "https://github.com/GrafeasGroup/blossom-wrapper.git",
 requests = "^2.25.1"
 PyYAML = "^5.3.1"
 python-dateutil = "^2.8.1"
+matplotlib = "^3.4.2"
 
 [tool.poetry.dev-dependencies]
 better-exceptions = "^0.2.2"


### PR DESCRIPTION
Relevant issue: Closes #21.

## Description:

Adds a `/history` command which creates a plot of the user's gamma over time. Multiple users can be provided to be plotted together.

Unfortunately, they are not correct yet due to the wrong dates in the Blossom API (GrafeasGroup/blossom#157).

What's missing in comparison to the old bot is that you can't specify a time frame to restrict the graph to. I am not sure yet how to integrate this properly with the Discord commands, so I want to move this to a separate issue. It's also not used that often, so we can omit it for now.

The command takes about 2.5 seconds for each provided user, which is a bit long. But it's a big improvement to the 45 seconds we had with a previous iteration. Maybe we can optimize the rate command in the API for shorter delays.

## Screenshots:

![Single user graph](https://user-images.githubusercontent.com/13908946/124944786-e7051a00-e00d-11eb-92a6-4e0f7681d669.png)

![Multi user graph](https://user-images.githubusercontent.com/13908946/124944736-dd7bb200-e00d-11eb-9801-7d86692efdfe.png)

## Checklist:

- [x] Code Quality
- [x] Pep-8
- [ ] Tests (if applicable)
- [x] Success Criteria Met
- [x] Inline Documentation
- [ ] Wiki Documentation (if applicable)
