### PR TITLE
Add stats command

### DIFF
--- a/buttercup/cogs/stats.py
+++ b/buttercup/cogs/stats.py
@@ -1,8 +1,5 @@
-from typing import Dict, Optional
-from urllib.parse import urlparse
-
-from blossom_wrapper import BlossomAPI, BlossomStatus
-from discord import Color, Embed
+from blossom_wrapper import BlossomAPI
+from discord import Embed
 from discord.ext.commands import Cog
 from discord_slash import SlashContext, cog_ext
 
@@ -19,14 +16,32 @@ class Stats(Cog):
         self.blossom_api = blossom_api
 
     @cog_ext.cog_slash(
-        name="stats",
-        description="Get stats about all users.",
+        name="stats", description="Get stats about all users.",
     )
     async def _stats(self, ctx: SlashContext) -> None:
         """Get stats about all users."""
         # Send a first message to show that the bot is responsive.
         # We will edit this message later with the actual content.
         msg = await ctx.send(f"Getting stats for all users...")
+
+        response = self.blossom_api.get("summary/")
+
+        if response.status_code != 200:
+            await msg.edit(content="Failed to get the stats for all users.")
+
+        data = response.json()
+
+        description = """**Volunteers**: {:,d}
+**Transcriptions**: {:,d}
+**Days Since Inception**: {:,d}""".format(
+            data["volunteer_count"],
+            data["transcription_count"],
+            data["days_since_inception"],
+        )
+
+        embed = Embed(title="Stats", description=description)
+
+        await msg.edit(embed=embed)
 
 
 def setup(bot: ButtercupBot) -> None:

--- a/buttercup/cogs/stats.py
+++ b/buttercup/cogs/stats.py
@@ -22,18 +22,16 @@ class Stats(Cog):
         """Get stats about all users."""
         # Send a first message to show that the bot is responsive.
         # We will edit this message later with the actual content.
-        msg = await ctx.send(f"Getting stats for all users...")
+        msg = await ctx.send(i18n["stats"]["getting_stats"])
 
         response = self.blossom_api.get("summary/")
 
         if response.status_code != 200:
-            await msg.edit(content="Failed to get the stats for all users.")
+            await msg.edit(content=i18n["stats"]["failed_getting_stats"])
 
         data = response.json()
 
-        description = """**Volunteers**: {:,d}
-**Transcriptions**: {:,d}
-**Days Since Inception**: {:,d}""".format(
+        description = i18n["stats"]["stats"].format(
             data["volunteer_count"],
             data["transcription_count"],
             data["days_since_inception"],

--- a/buttercup/cogs/stats.py
+++ b/buttercup/cogs/stats.py
@@ -1,0 +1,44 @@
+from typing import Dict, Optional
+from urllib.parse import urlparse
+
+from blossom_wrapper import BlossomAPI, BlossomStatus
+from discord import Color, Embed
+from discord.ext.commands import Cog
+from discord_slash import SlashContext, cog_ext
+
+from buttercup.bot import ButtercupBot
+from buttercup.strings import translation
+
+i18n = translation()
+
+
+class Stats(Cog):
+    def __init__(self, bot: ButtercupBot, blossom_api: BlossomAPI) -> None:
+        """Initialize the Stats cog."""
+        self.bot = bot
+        self.blossom_api = blossom_api
+
+    @cog_ext.cog_slash(
+        name="stats",
+        description="Get stats about all users.",
+    )
+    async def _stats(self, ctx: SlashContext) -> None:
+        """Get stats about all users."""
+        # Send a first message to show that the bot is responsive.
+        # We will edit this message later with the actual content.
+        msg = await ctx.send(f"Getting stats for all users...")
+
+
+def setup(bot: ButtercupBot) -> None:
+    """Set up the Stats cog."""
+    cog_config = bot.config["Blossom"]
+    email = cog_config.get("email")
+    password = cog_config.get("password")
+    api_key = cog_config.get("api_key")
+    blossom_api = BlossomAPI(email=email, password=password, api_key=api_key)
+    bot.add_cog(Stats(bot=bot, blossom_api=blossom_api))
+
+
+def teardown(bot: ButtercupBot) -> None:
+    """Unload the Stats cog."""
+    bot.remove_cog("Stats")

--- a/buttercup/cogs/stats.py
+++ b/buttercup/cogs/stats.py
@@ -31,15 +31,16 @@ class Stats(Cog):
 
         data = response.json()
 
-        description = i18n["stats"]["stats"].format(
+        description = i18n["stats"]["embed_description"].format(
             data["volunteer_count"],
             data["transcription_count"],
             data["days_since_inception"],
         )
 
-        embed = Embed(title="Stats", description=description)
-
-        await msg.edit(embed=embed)
+        await msg.edit(
+            content=i18n["stats"]["embed_message"],
+            embed=Embed(title=i18n["stats"]["embed_title"], description=description),
+        )
 
 
 def setup(bot: ButtercupBot) -> None:

--- a/buttercup/main.py
+++ b/buttercup/main.py
@@ -3,7 +3,7 @@ import sys
 from buttercup import logger
 from buttercup.bot import ButtercupBot
 
-EXTENSIONS = ["admin", "handlers", "name_validator", "find"]
+EXTENSIONS = ["admin", "handlers", "name_validator", "find", "stats"]
 
 
 logger.configure_logging()

--- a/buttercup/strings/en_US.yaml
+++ b/buttercup/strings/en_US.yaml
@@ -23,3 +23,12 @@ find:
   please_check_url: |
     Please check that your link is correct; it should lead to either a post on r/TranscribersOfReddit, a post on a partner sub or to a transcription.
   discord_username_link: "[{0}](https://reddit.com/u/{0})"
+stats:
+  getting_stats: |
+    Getting stats for all users...
+  failed_getting_stats: |
+    Failed to get the stats for all users.
+  stats: |
+    **Volunteers**: {:,d}
+    **Transcriptions**: {:,d}
+    **Days Since Inception**: {:,d}

--- a/buttercup/strings/en_US.yaml
+++ b/buttercup/strings/en_US.yaml
@@ -28,7 +28,11 @@ stats:
     Getting stats for all users...
   failed_getting_stats: |
     Failed to get the stats for all users.
-  stats: |
+  embed_message: |
+    Here are the stats!
+  embed_title: |
+    Stats For All Users
+  embed_description: |
     **Volunteers**: {:,d}
     **Transcriptions**: {:,d}
     **Days Since Inception**: {:,d}


### PR DESCRIPTION
Relevant issue: Closes #19.

## Description:

Adds a `/stats` command that displays statistics about all users of the server.

## Screenshots:

![Response of the bot to the `/stats` command](https://user-images.githubusercontent.com/13908946/122292850-b9d5b800-cef6-11eb-8314-7c6835e94121.png)

## Checklist:

- [x] Code Quality
- [x] Pep-8
- [ ] Tests (if applicable)
- [x] Success Criteria Met
- [x] Inline Documentation
- [ ] Wiki Documentation (if applicable)
