### PR TITLE
Add `/heatmap` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ restrict_channel = "new-user"
 welcome_channel = "off-topic"
 
 [Blossom]
-username = ""
+email = ""
 password = ""
 api_key = ""
 ```

--- a/buttercup/bot.py
+++ b/buttercup/bot.py
@@ -24,7 +24,7 @@ class ButtercupBot(Bot):
         intents.members = True
         super().__init__(command_prefix, intents=intents, **kwargs)
         self.slash = SlashCommand(self, sync_commands=True, sync_on_cog_reload=True)
-        self.config_path = kwargs.get("config_path", "config.toml")
+        self.config_path = kwargs.get("config_path", "../config.toml")
         self.cog_path = kwargs.get("cog_path", "buttercup.cogs.")
         self.guild_name = self.config["guild"]["name"]
 

--- a/buttercup/cogs/__init__.py
+++ b/buttercup/cogs/__init__.py
@@ -1,1 +1,20 @@
 """The cogs which provide the functionality to the bot."""
+
+# Colors to use in the plots
+from matplotlib import pyplot as plt
+
+background_color = "#36393f"  # Discord background color
+text_color = "white"
+line_color = "white"
+
+# Global settings for all plots
+plt.rcParams["figure.facecolor"] = background_color
+plt.rcParams["axes.facecolor"] = background_color
+plt.rcParams["axes.labelcolor"] = text_color
+plt.rcParams["axes.edgecolor"] = line_color
+plt.rcParams["text.color"] = text_color
+plt.rcParams["xtick.color"] = line_color
+plt.rcParams["ytick.color"] = line_color
+plt.rcParams["grid.color"] = line_color
+plt.rcParams["grid.alpha"] = 0.8
+plt.rcParams["figure.dpi"] = 200.0

--- a/buttercup/cogs/handlers.py
+++ b/buttercup/cogs/handlers.py
@@ -6,6 +6,9 @@ from discord.ext import commands
 from buttercup import logger
 from buttercup.bot import ButtercupBot
 from buttercup.cogs.helpers import NoUsernameError
+from buttercup.strings import translation
+
+i18n = translation()
 
 
 class Handlers(commands.Cog):
@@ -26,24 +29,14 @@ class Handlers(commands.Cog):
         """Log that a command has errored and provide the user with feedback."""
         if isinstance(error, commands.CheckFailure):
             logger.warning("An unauthorized Command was performed.", ctx)
-            await ctx.send(
-                "You are not authorized to use this command. "
-                "This incident will be reported"
-            )
+            await ctx.send(i18n["handlers"]["not_authorized"])
         elif isinstance(error, NoUsernameError):
             logger.warning("Command executed without providing a username.", ctx)
-            await ctx.send(
-                "You did not provide a valid username. "
-                "Either add it to the command or change your display name "
-                "to a valid format."
-            )
+            await ctx.send(i18n["handlers"]["no_username"])
         else:
             tracker_id = uuid.uuid4()
             logger.warning(f"[{tracker_id}] {type(error).__name__}: {str(error)}", ctx)
-            await ctx.send(
-                f"[{tracker_id}] Something went wrong, "
-                "please contact a moderator with the provided ID."
-            )
+            await ctx.send(i18n["handlers"]["unknown_error"].format(tracker_id))
 
 
 def setup(bot: ButtercupBot) -> None:

--- a/buttercup/cogs/handlers.py
+++ b/buttercup/cogs/handlers.py
@@ -5,6 +5,7 @@ from discord.ext import commands
 
 from buttercup import logger
 from buttercup.bot import ButtercupBot
+from buttercup.cogs.helpers import NoUsernameError
 
 
 class Handlers(commands.Cog):
@@ -28,6 +29,13 @@ class Handlers(commands.Cog):
             await ctx.send(
                 "You are not authorized to use this command. "
                 "This incident will be reported"
+            )
+        elif isinstance(error, NoUsernameError):
+            logger.warning("Command executed without providing a username.", ctx)
+            await ctx.send(
+                "You did not provide a valid username. "
+                "Either add it to the command or change your display name "
+                "to a valid format."
             )
         else:
             tracker_id = uuid.uuid4()

--- a/buttercup/cogs/heatmap.py
+++ b/buttercup/cogs/heatmap.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 from typing import Optional
 
+import matplotlib.pyplot as plt
 from blossom_wrapper import BlossomAPI
 from discord.ext.commands import Cog
 from discord_slash import SlashContext, cog_ext
@@ -33,11 +34,32 @@ class Heatmap(Cog):
 
 def setup(bot: ButtercupBot) -> None:
     """Set up the Heatmap cog."""
+    # Initialize blossom api
     cog_config = bot.config["Blossom"]
     email = cog_config.get("email")
     password = cog_config.get("password")
     api_key = cog_config.get("api_key")
     blossom_api = BlossomAPI(email=email, password=password, api_key=api_key)
+
+    # Initialize PyPlot
+
+    # Colors to use in the plots
+    background_color = "#36393f"  # Discord background color
+    text_color = "white"
+    line_color = "white"
+
+    # Global settings for the plots
+    plt.rcParams["figure.facecolor"] = background_color
+    plt.rcParams["axes.facecolor"] = background_color
+    plt.rcParams["axes.labelcolor"] = text_color
+    plt.rcParams["axes.edgecolor"] = line_color
+    plt.rcParams["text.color"] = text_color
+    plt.rcParams["xtick.color"] = line_color
+    plt.rcParams["ytick.color"] = line_color
+    plt.rcParams["grid.color"] = line_color
+    plt.rcParams["grid.alpha"] = 0.8
+    plt.rcParams["figure.dpi"] = 200.0
+
     bot.add_cog(Heatmap(bot=bot, blossom_api=blossom_api))
 
 

--- a/buttercup/cogs/heatmap.py
+++ b/buttercup/cogs/heatmap.py
@@ -1,8 +1,7 @@
 import io
-from typing import Optional, Dict, List
+from typing import Dict, List, Optional
 
 import matplotlib.pyplot as plt
-import matplotlib.table as tbl
 from blossom_wrapper import BlossomAPI
 from discord import File
 from discord.ext.commands import Cog
@@ -169,7 +168,7 @@ def create_file_from_heatmap(
     for (row, col), cell in table.get_celld().items():
         # Make headers bold
         if (row == 0) or (col == -1):
-            cell.set_text_props(fontproperties=FontProperties(weight='bold'))
+            cell.set_text_props(fontproperties=FontProperties(weight="bold"))
 
         # Remove cell edges
         # Setting edges="open" removes the cell colors for some reason
@@ -202,9 +201,9 @@ class Heatmap(Cog):
         options=[
             create_option(
                 name="username",
-                description="The user to get the heatmap for. Defaults to the user executing the command.",
+                description="The user to get the heatmap for.",
                 option_type=3,
-                required=False,
+                required=True,
             )
         ],
     )

--- a/buttercup/cogs/heatmap.py
+++ b/buttercup/cogs/heatmap.py
@@ -12,7 +12,11 @@ from discord_slash import SlashContext, cog_ext
 from discord_slash.utils.manage_commands import create_option
 
 from buttercup.bot import ButtercupBot
-from buttercup.cogs.helpers import extract_username, get_duration_str, extract_utc_offset
+from buttercup.cogs.helpers import (
+    extract_username,
+    extract_utc_offset,
+    get_duration_str,
+)
 from buttercup.strings import translation
 
 i18n = translation()

--- a/buttercup/cogs/heatmap.py
+++ b/buttercup/cogs/heatmap.py
@@ -31,6 +31,15 @@ class Heatmap(Cog):
         """Generate a heatmap for the given user."""
         msg = await ctx.send(f"Generating a heatmap for u/{username}...")
 
+        response = self.blossom_api.get("volunteer/heatmap/", params={"username": username})
+
+        if response.status_code != 200:
+            await msg.edit(content=f"User u/{username} not found!")
+            return
+
+        data = response.json()
+        await msg.edit(content=f"Data: {data}")
+
 
 def setup(bot: ButtercupBot) -> None:
     """Set up the Heatmap cog."""

--- a/buttercup/cogs/heatmap.py
+++ b/buttercup/cogs/heatmap.py
@@ -14,6 +14,8 @@ from buttercup.bot import ButtercupBot
 
 
 # Colors to use in the plots
+from buttercup.cogs.helpers import extract_username
+
 background_color = "#36393f"  # Discord background color
 text_color = "white"
 line_color = "white"
@@ -77,20 +79,21 @@ class Heatmap(Cog):
                 name="username",
                 description="The user to get the heatmap for.",
                 option_type=3,
-                required=True,
+                required=False,
             )
         ],
     )
     async def _heatmap(self, ctx: SlashContext, username: Optional[str] = None) -> None:
         """Generate a heatmap for the given user."""
-        msg = await ctx.send(f"Generating a heatmap for u/{username}...")
+        user = username or extract_username(ctx.author.display_name)
+        msg = await ctx.send(f"Generating a heatmap for u/{user}...")
 
         response = self.blossom_api.get(
-            "volunteer/heatmap/", params={"username": username}
+            "volunteer/heatmap/", params={"username": user}
         )
 
         if response.status_code != 200:
-            await msg.edit(content=f"User u/{username} not found!")
+            await msg.edit(content=f"User u/{user} not found!")
             return
 
         data = response.json()
@@ -107,10 +110,10 @@ class Heatmap(Cog):
             .reindex(index=day_index, columns=hour_index)
         )
 
-        heatmap_table = create_file_from_heatmap(heatmap, username)
+        heatmap_table = create_file_from_heatmap(heatmap, user)
 
         await msg.edit(
-            content=f"Here is the heatmap for u/{username}:", file=heatmap_table
+            content=f"Here is the heatmap for u/{user}:", file=heatmap_table
         )
 
 

--- a/buttercup/cogs/heatmap.py
+++ b/buttercup/cogs/heatmap.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Optional
+from typing import Optional, Dict, List
 
 import matplotlib.pyplot as plt
 from blossom_wrapper import BlossomAPI
@@ -10,6 +10,39 @@ from discord_slash.utils.manage_commands import create_option
 from buttercup.bot import ButtercupBot
 
 
+def init_heatmap_dict() -> Dict[int, Dict[int, int]]:
+    """Get the initial dictionary for the heatmap data.
+
+    For every day (1 = Monday, 7 = Sunday), it contains a dict entry
+    with an entry 0 for every hour.
+    """
+    heatmap_dict = {}
+
+    for day in range(1, 8):
+        day_dict = {}
+
+        for hour in range(0, 24):
+            day_dict[hour] = 0
+
+        heatmap_dict[day] = day_dict
+
+    return heatmap_dict
+
+
+def get_heatmap_dict(data: List[Dict[str, int]]) -> Dict[int, Dict[int, int]]:
+    """Populate the heatmap dictionary with the data returned by Blossom."""
+    heatmap_dict = init_heatmap_dict()
+
+    for entry in data:
+        day = entry["day"]
+        hour = entry["hour"]
+        count = entry["count"]
+
+        heatmap_dict[day][hour] += count
+
+    return heatmap_dict
+
+
 class Heatmap(Cog):
     def __init__(self, bot: ButtercupBot, blossom_api: BlossomAPI) -> None:
         """Initialize the Heatmap cog."""
@@ -17,7 +50,8 @@ class Heatmap(Cog):
         self.blossom_api = blossom_api
 
     @cog_ext.cog_slash(
-        name="heatmap", description="Display the activity heatmap for the given user.",
+        name="heatmap",
+        description="Display the activity heatmap for the given user.",
         options=[
             create_option(
                 name="username",
@@ -31,14 +65,18 @@ class Heatmap(Cog):
         """Generate a heatmap for the given user."""
         msg = await ctx.send(f"Generating a heatmap for u/{username}...")
 
-        response = self.blossom_api.get("volunteer/heatmap/", params={"username": username})
+        response = self.blossom_api.get(
+            "volunteer/heatmap/", params={"username": username}
+        )
 
         if response.status_code != 200:
             await msg.edit(content=f"User u/{username} not found!")
             return
 
         data = response.json()
-        await msg.edit(content=f"Data: {data}")
+        heatmap_dict = get_heatmap_dict(data)
+
+        await msg.edit(content=f"Data: {heatmap_dict}")
 
 
 def setup(bot: ButtercupBot) -> None:

--- a/buttercup/cogs/heatmap.py
+++ b/buttercup/cogs/heatmap.py
@@ -12,7 +12,7 @@ from discord_slash import SlashContext, cog_ext
 from discord_slash.utils.manage_commands import create_option
 
 from buttercup.bot import ButtercupBot
-from buttercup.cogs.helpers import extract_username, get_duration_str
+from buttercup.cogs.helpers import extract_username, get_duration_str, extract_utc_offset
 from buttercup.strings import translation
 
 i18n = translation()
@@ -84,6 +84,7 @@ class Heatmap(Cog):
         """Generate a heatmap for the given user."""
         start = datetime.now()
         user = username or extract_username(ctx.author.display_name)
+        utc_offset = extract_utc_offset(ctx.author.display_name)
         msg = await ctx.send(i18n["heatmap"]["getting_heatmap"].format(user))
 
         response = self.blossom_api.get("volunteer/heatmap/", params={"username": user})
@@ -106,7 +107,7 @@ class Heatmap(Cog):
             .reindex(index=day_index, columns=hour_index)
         )
 
-        heatmap_table = create_file_from_heatmap(heatmap, user)
+        heatmap_table = create_file_from_heatmap(heatmap, user, utc_offset)
 
         await msg.edit(
             content=i18n["heatmap"]["response_message"].format(

--- a/buttercup/cogs/heatmap.py
+++ b/buttercup/cogs/heatmap.py
@@ -50,7 +50,6 @@ def create_file_from_heatmap(
         yticklabels=days,
     )
 
-    # TODO: Make this dependant on the user's timezone set in the display name
     timezone = "UTC" if utc_offset == 0 else f"UTC{utc_offset:+d}"
 
     plt.title(i18n["heatmap"]["plot_title"].format(username))

--- a/buttercup/cogs/heatmap.py
+++ b/buttercup/cogs/heatmap.py
@@ -17,11 +17,6 @@ from buttercup.strings import translation
 
 i18n = translation()
 
-# Colors to use in the plots
-background_color = "#36393f"  # Discord background color
-text_color = "white"
-line_color = "white"
-
 
 def create_file_from_heatmap(heatmap: pd.DataFrame, username: str,) -> File:
     """Create a Discord file containing the heatmap table."""
@@ -120,19 +115,6 @@ def setup(bot: ButtercupBot) -> None:
     password = cog_config.get("password")
     api_key = cog_config.get("api_key")
     blossom_api = BlossomAPI(email=email, password=password, api_key=api_key)
-
-    # Initialize PyPlot
-    # Global settings for the plots
-    plt.rcParams["figure.facecolor"] = background_color
-    plt.rcParams["axes.facecolor"] = background_color
-    plt.rcParams["axes.labelcolor"] = text_color
-    plt.rcParams["axes.edgecolor"] = line_color
-    plt.rcParams["text.color"] = text_color
-    plt.rcParams["xtick.color"] = line_color
-    plt.rcParams["ytick.color"] = line_color
-    plt.rcParams["grid.color"] = line_color
-    plt.rcParams["grid.alpha"] = 0.8
-    plt.rcParams["figure.dpi"] = 200.0
 
     bot.add_cog(Heatmap(bot=bot, blossom_api=blossom_api))
 

--- a/buttercup/cogs/heatmap.py
+++ b/buttercup/cogs/heatmap.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 import io
 from typing import Optional, Dict, List
 
@@ -9,11 +8,33 @@ from discord import File
 from discord.ext.commands import Cog
 from discord_slash import SlashContext, cog_ext
 from discord_slash.utils.manage_commands import create_option
+from matplotlib.font_manager import FontProperties
 
 from buttercup.bot import ButtercupBot
 
 
-def init_heatmap_dict() -> Dict[int, Dict[int, int]]:
+# Colors to use in the plots
+background_color = "#36393f"  # Discord background color
+text_color = "white"
+line_color = "white"
+intensity_colors = [
+    "#07102c",
+    "#0a1842",
+    "#0e2058",
+    "#11286e",
+    "#153184",
+    "#18399a",
+    "#1c41b0",
+    "#1f49c7",
+    "#2251dd",
+    "#3862e0",
+]
+
+
+Heatmap = Dict[int, Dict[int, int]]
+
+
+def init_heatmap_dict() -> Heatmap:
     """Get the initial dictionary for the heatmap data.
 
     For every day (1 = Monday, 7 = Sunday), it contains a dict entry
@@ -32,7 +53,7 @@ def init_heatmap_dict() -> Dict[int, Dict[int, int]]:
     return heatmap_dict
 
 
-def get_heatmap_dict(data: List[Dict[str, int]]) -> Dict[int, Dict[int, int]]:
+def get_heatmap_dict(data: List[Dict[str, int]]) -> Heatmap:
     """Populate the heatmap dictionary with the data returned by Blossom."""
     heatmap_dict = init_heatmap_dict()
 
@@ -46,7 +67,7 @@ def get_heatmap_dict(data: List[Dict[str, int]]) -> Dict[int, Dict[int, int]]:
     return heatmap_dict
 
 
-def get_cell_text(heatmap_dict: Dict[int, Dict[int, int]]) -> List[List[str]]:
+def get_cell_texts(heatmap_dict: Heatmap) -> List[List[str]]:
     """Get the text for each cell of the table."""
     rows = []
 
@@ -64,12 +85,51 @@ def get_cell_text(heatmap_dict: Dict[int, Dict[int, int]]) -> List[List[str]]:
     return rows
 
 
+def get_max_value(heatmap_dict: Heatmap) -> int:
+    """Calculate the maximum value in the heatmap."""
+    max_value = 0
+
+    for day in heatmap_dict:
+        day_data = heatmap_dict[day]
+
+        for hour in day_data:
+            hour_data = day_data[hour]
+
+            max_value = max(max_value, hour_data)
+
+    return max_value
+
+
+def get_cell_colors(heatmap_dict: Heatmap) -> List[List[str]]:
+    """Get the color for each cell of the table."""
+    rows = []
+    max_value = get_max_value(heatmap_dict)
+
+    for day in heatmap_dict:
+        cols = []
+        day_data = heatmap_dict[day]
+
+        for hour in day_data:
+            value = day_data[hour]
+
+            if value == 0:
+                cols.append(background_color)
+                continue
+
+            percentage = value / max_value
+            intensity = round(percentage * (len(intensity_colors) - 1))
+            color = intensity_colors[intensity]
+            cols.append(color)
+
+        rows.append(cols)
+
+    return rows
+
+
 def create_file_from_heatmap(
     heatmap_dict: Dict[int, Dict[int, int]], username: str,
 ) -> File:
     """Create a Discord file containing the heatmap table."""
-    background_color = "#36393f"  # Discord background color
-
     days = [
         "Monday",
         "Tuesday",
@@ -80,10 +140,11 @@ def create_file_from_heatmap(
         "Sunday",
     ]
     hours = ["{:02d}".format(hour) for hour in range(0, 24)]
-    cells = get_cell_text(heatmap_dict)
+    cells = get_cell_texts(heatmap_dict)
 
     row_colors = [background_color for _ in range(0, 7)]
     col_colors = [background_color for _ in range(0, 24)]
+    cell_colors = get_cell_colors(heatmap_dict)
 
     fig, ax = plt.subplots()
 
@@ -91,17 +152,27 @@ def create_file_from_heatmap(
     ax.axis("off")
     ax.axis("tight")
 
-    ax.table(
+    table = ax.table(
         rowLoc="right",
         rowLabels=days,
         rowColours=row_colors,
         colLoc="center",
         colLabels=hours,
         colColours=col_colors,
+        cellLoc="center",
         cellText=cells,
+        cellColours=cell_colors,
         loc="center",
-        edges="",
     )
+
+    for (row, col), cell in table.get_celld().items():
+        # Make headers bold
+        if (row == 0) or (col == -1):
+            cell.set_text_props(fontproperties=FontProperties(weight='bold'))
+
+        # Remove cell edges
+        # Setting edges="open" removes the cell colors for some reason
+        cell.set_linewidth(0)
 
     heatmap_table = io.BytesIO()
     plt.savefig(heatmap_table, format="png")
@@ -160,12 +231,6 @@ def setup(bot: ButtercupBot) -> None:
     blossom_api = BlossomAPI(email=email, password=password, api_key=api_key)
 
     # Initialize PyPlot
-
-    # Colors to use in the plots
-    background_color = "#36393f"  # Discord background color
-    text_color = "white"
-    line_color = "white"
-
     # Global settings for the plots
     plt.rcParams["figure.facecolor"] = background_color
     plt.rcParams["axes.facecolor"] = background_color

--- a/buttercup/cogs/heatmap.py
+++ b/buttercup/cogs/heatmap.py
@@ -40,7 +40,8 @@ def create_file_from_heatmap(heatmap: pd.DataFrame, username: str,) -> File:
     )
 
     fig, ax = plt.subplots()
-    fig.set_size_inches(14, 5.0)
+    fig.set_size_inches(9, 3.2)
+    plt.title(f"Activity Heatmap for u/{username}")
 
     sns.heatmap(
         heatmap,
@@ -53,6 +54,7 @@ def create_file_from_heatmap(heatmap: pd.DataFrame, username: str,) -> File:
         yticklabels=days,
     )
 
+    fig.tight_layout()
     heatmap_table = io.BytesIO()
     plt.savefig(heatmap_table, format="png")
     heatmap_table.seek(0)

--- a/buttercup/cogs/heatmap.py
+++ b/buttercup/cogs/heatmap.py
@@ -131,13 +131,13 @@ def create_file_from_heatmap(
 ) -> File:
     """Create a Discord file containing the heatmap table."""
     days = [
-        "Monday",
-        "Tuesday",
-        "Wednesday",
-        "Thursday",
-        "Friday",
-        "Saturday",
-        "Sunday",
+        "Mon",
+        "Tue",
+        "Wed",
+        "Thu",
+        "Fri",
+        "Sat",
+        "Sun",
     ]
     hours = ["{:02d}".format(hour) for hour in range(0, 24)]
     cells = get_cell_texts(heatmap_dict)
@@ -147,6 +147,7 @@ def create_file_from_heatmap(
     cell_colors = get_cell_colors(heatmap_dict)
 
     fig, ax = plt.subplots()
+    fig.set_size_inches(18.5, 5.0)
 
     # hide axes
     ax.axis("off")
@@ -173,6 +174,13 @@ def create_file_from_heatmap(
         # Remove cell edges
         # Setting edges="open" removes the cell colors for some reason
         cell.set_linewidth(0)
+        # Increase size
+        cell.set_height(0.15)
+        cell.set_width(0.05)
+
+    # Make text bigger
+    table.auto_set_font_size(False)
+    table.set_fontsize(19)
 
     heatmap_table = io.BytesIO()
     plt.savefig(heatmap_table, format="png")

--- a/buttercup/cogs/heatmap.py
+++ b/buttercup/cogs/heatmap.py
@@ -1,0 +1,46 @@
+from datetime import datetime
+from typing import Optional
+
+from blossom_wrapper import BlossomAPI
+from discord.ext.commands import Cog
+from discord_slash import SlashContext, cog_ext
+from discord_slash.utils.manage_commands import create_option
+
+from buttercup.bot import ButtercupBot
+
+
+class Heatmap(Cog):
+    def __init__(self, bot: ButtercupBot, blossom_api: BlossomAPI) -> None:
+        """Initialize the Heatmap cog."""
+        self.bot = bot
+        self.blossom_api = blossom_api
+
+    @cog_ext.cog_slash(
+        name="heatmap", description="Display the activity heatmap for the given user.",
+        options=[
+            create_option(
+                name="username",
+                description="The user to get the heatmap for. Defaults to the user executing the command.",
+                option_type=3,
+                required=False,
+            )
+        ],
+    )
+    async def _heatmap(self, ctx: SlashContext, username: Optional[str] = None) -> None:
+        """Generate a heatmap for the given user."""
+        msg = await ctx.send(f"Generating a heatmap for u/{username}...")
+
+
+def setup(bot: ButtercupBot) -> None:
+    """Set up the Heatmap cog."""
+    cog_config = bot.config["Blossom"]
+    email = cog_config.get("email")
+    password = cog_config.get("password")
+    api_key = cog_config.get("api_key")
+    blossom_api = BlossomAPI(email=email, password=password, api_key=api_key)
+    bot.add_cog(Heatmap(bot=bot, blossom_api=blossom_api))
+
+
+def teardown(bot: ButtercupBot) -> None:
+    """Unload the Heatmap cog."""
+    bot.remove_cog("Heatmap")

--- a/buttercup/cogs/heatmap.py
+++ b/buttercup/cogs/heatmap.py
@@ -1,6 +1,6 @@
 import io
 from datetime import datetime
-from typing import Optional
+from typing import Any, Dict, Optional
 
 import matplotlib.pyplot as plt
 import pandas as pd
@@ -65,39 +65,13 @@ def create_file_from_heatmap(
     return File(heatmap_table, "heatmap_table.png")
 
 
-def adjust_timezone(heatmap: pd.DataFrame, utc_offset: int) -> pd.DataFrame:
-    """Adjust the heatmap to the given UTC offset."""
-    result = heatmap
-    forward = utc_offset > 0
-
-    # TODO: Make this more efficient
-    # Suppose we have a data frame like this:
-    #     A  B  C
-    # D   1  2  3
-    # E   4  5  6
-    # F   7  8  9
-    # With each iteration, we shift like this:
-    #     A  B  C
-    # D   9  1  2
-    # E   3  4  5
-    # F   6  7  8
-    # Assuming we have a positive UTC offset.
-    for _ in range(0, abs(utc_offset)):
-        periods = 1 if forward else -1
-        wrap_column = result[23] if forward else result[0]
-        wrap_value = wrap_column[7] if forward else wrap_column[1]
-        wrap_column = wrap_column.shift(periods=periods)
-        if forward:
-            wrap_column[1] = wrap_value
-        else:
-            wrap_column[7] = wrap_value
-        result = result.shift(periods=periods, axis="columns")
-        if forward:
-            result[0] = wrap_column
-        else:
-            result[23] = wrap_column
-
-    return result
+def adjust_with_timezone(hour_data: Dict[str, Any], utc_offset: int) -> Dict[str, Any]:
+    """Adjust the heatmap data according to the UTC offset of the user."""
+    hour_offset = hour_data["hour"] + utc_offset
+    new_hour = hour_offset % 24
+    # The days go from 1 to 7, so we need to adjust this to zero index and back
+    new_day = ((hour_data["day"] + hour_offset // 24) - 1) % 7 + 1
+    return {"day": new_day, "hour": new_hour, "count": hour_data["count"]}
 
 
 class Heatmap(Cog):
@@ -132,20 +106,19 @@ class Heatmap(Cog):
             return
 
         data = response.json()
+        data = [adjust_with_timezone(hour_data, utc_offset) for hour_data in data]
 
         day_index = pd.Index(range(1, 8))
         hour_index = pd.Index(range(0, 24))
 
         heatmap = (
             # Create a data frame from the data
-            pd.DataFrame.from_dict(data)
+            pd.DataFrame.from_records(data)
             # Convert it into a table with the days as rows and hours as columns
             .pivot(index="day", columns="hour", values="count")
             # Add the missing days and hours
             .reindex(index=day_index, columns=hour_index)
         )
-
-        heatmap = adjust_timezone(heatmap, utc_offset)
 
         heatmap_table = create_file_from_heatmap(heatmap, user, utc_offset)
 

--- a/buttercup/cogs/helpers.py
+++ b/buttercup/cogs/helpers.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from datetime import datetime
 import re
 
 from discord import DiscordException
@@ -16,3 +16,10 @@ def extract_username(display_name: str) -> str:
     if match is None:
         raise NoUsernameError()
     return match.group("username")
+
+
+def get_duration_str(start: datetime) -> str:
+    """Get the processing duration based on the start time."""
+    duration = datetime.now() - start
+    duration_ms = duration.microseconds / 1000
+    return f"{duration_ms:0.0f} ms"

--- a/buttercup/cogs/helpers.py
+++ b/buttercup/cogs/helpers.py
@@ -19,6 +19,15 @@ def extract_username(display_name: str) -> str:
     return match.group("username")
 
 
+def extract_utc_offset(display_name: str) -> int:
+    """Extract the user's timezone (UTC offset) from the display name."""
+    pattern = re.compile(r"UTC(?P<offset>[+-]\d+)?", re.RegexFlag.I)
+    match = pattern.search(display_name)
+    if match is None or match.group("offset") is None:
+        return 0
+    return int(match.group("offset"))
+
+
 def get_duration_str(start: datetime) -> str:
     """Get the processing duration based on the start time."""
     duration = datetime.now() - start

--- a/buttercup/cogs/helpers.py
+++ b/buttercup/cogs/helpers.py
@@ -1,0 +1,18 @@
+from typing import Optional
+import re
+
+from discord import DiscordException
+
+
+class NoUsernameError(DiscordException):
+    """Exception raised when the username was not provided."""
+    pass
+
+
+def extract_username(display_name: str) -> str:
+    """Extract the Reddit username from the display name."""
+    pattern = re.compile(r"^/?u/(?P<username>\S+)")
+    match = pattern.search(display_name)
+    if match is None:
+        raise NoUsernameError()
+    return match.group("username")

--- a/buttercup/cogs/helpers.py
+++ b/buttercup/cogs/helpers.py
@@ -3,6 +3,9 @@ from datetime import datetime
 
 from discord import DiscordException
 
+username_regex = re.compile(r"^/?u/(?P<username>\S+)")
+timezone_regex = re.compile(r"UTC(?P<offset>[+-]\d+)?", re.RegexFlag.I)
+
 
 class NoUsernameError(DiscordException):
     """Exception raised when the username was not provided."""
@@ -12,8 +15,7 @@ class NoUsernameError(DiscordException):
 
 def extract_username(display_name: str) -> str:
     """Extract the Reddit username from the display name."""
-    pattern = re.compile(r"^/?u/(?P<username>\S+)")
-    match = pattern.search(display_name)
+    match = username_regex.search(display_name)
     if match is None:
         raise NoUsernameError()
     return match.group("username")
@@ -21,8 +23,7 @@ def extract_username(display_name: str) -> str:
 
 def extract_utc_offset(display_name: str) -> int:
     """Extract the user's timezone (UTC offset) from the display name."""
-    pattern = re.compile(r"UTC(?P<offset>[+-]\d+)?", re.RegexFlag.I)
-    match = pattern.search(display_name)
+    match = timezone_regex.search(display_name)
     if match is None or match.group("offset") is None:
         return 0
     return int(match.group("offset"))

--- a/buttercup/cogs/helpers.py
+++ b/buttercup/cogs/helpers.py
@@ -6,6 +6,7 @@ from discord import DiscordException
 
 class NoUsernameError(DiscordException):
     """Exception raised when the username was not provided."""
+
     pass
 
 

--- a/buttercup/cogs/helpers.py
+++ b/buttercup/cogs/helpers.py
@@ -1,5 +1,5 @@
-from datetime import datetime
 import re
+from datetime import datetime
 
 from discord import DiscordException
 

--- a/buttercup/main.py
+++ b/buttercup/main.py
@@ -3,7 +3,16 @@ import sys
 from buttercup import logger
 from buttercup.bot import ButtercupBot
 
-EXTENSIONS = ["admin", "handlers", "name_validator", "find", "stats", "heatmap", "ping", "rules"]
+EXTENSIONS = [
+    "admin",
+    "handlers",
+    "name_validator",
+    "find",
+    "stats",
+    "heatmap",
+    "ping",
+    "rules",
+]
 
 
 logger.configure_logging()

--- a/buttercup/main.py
+++ b/buttercup/main.py
@@ -3,7 +3,7 @@ import sys
 from buttercup import logger
 from buttercup.bot import ButtercupBot
 
-EXTENSIONS = ["admin", "handlers", "name_validator", "find", "stats", "ping"]
+EXTENSIONS = ["admin", "handlers", "name_validator", "find", "stats", "heatmap", "ping"]
 
 
 logger.configure_logging()

--- a/buttercup/strings/en_US.yaml
+++ b/buttercup/strings/en_US.yaml
@@ -1,3 +1,10 @@
+handlers:
+  not_authorized: |
+    You are not authorized to use this command. This incident will be reported.
+  no_username: |
+    You did not provide a valid username. Either add it to the command or change your display name to a valid format.
+  unknown_error: |
+    [{0}] Something went wrong, please contact a moderator with the provided ID.
 name_validator:
   new_member: |
     Hello, <@{0}>! Welcome to the Transcribers of Reddit chill room! Thanks for helping make somebody's day better!
@@ -36,3 +43,20 @@ stats:
     **Volunteers**: {:,d}
     **Transcriptions**: {:,d}
     **Days Since Inception**: {:,d}
+heatmap:
+  getting_heatmap: |
+    Generating a heatmap for u/{0}...
+  user_not_found: |
+    Sorry, I couldn't find the user u/{0}.
+  days:
+    - Mon
+    - Tue
+    - Wed
+    - Thu
+    - Fri
+    - Sat
+    - Sun
+  plot_title: |
+    Activity Heatmap for u/{0}
+  response_message: |
+    Here is the heatmap for u/{0}! ({1})

--- a/buttercup/strings/en_US.yaml
+++ b/buttercup/strings/en_US.yaml
@@ -58,6 +58,10 @@ heatmap:
     - Sun
   plot_title: |
     Activity Heatmap for u/{0}
+  plot_xlabel: |
+    Time ({0})
+  plot_ylabel: |
+    Weekday
   response_message: |
     Here is the heatmap for u/{0}! ({1})
 rules:

--- a/poetry.lock
+++ b/poetry.lock
@@ -156,6 +156,17 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
+name = "cycler"
+version = "0.10.0"
+description = "Composable style cycles"
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+six = "*"
+
+[[package]]
 name = "discord-py-slash-command"
 version = "1.2.2"
 description = "A simple discord slash command handler for discord.py."
@@ -306,6 +317,30 @@ requirements = ["pipreqs", "pip-api"]
 xdg_home = ["appdirs (>=1.4.0)"]
 
 [[package]]
+name = "kiwisolver"
+version = "1.3.1"
+description = "A fast implementation of the Cassowary constraint solver"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[[package]]
+name = "matplotlib"
+version = "3.4.2"
+description = "Python plotting package"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+cycler = ">=0.10"
+kiwisolver = ">=1.0.1"
+numpy = ">=1.16"
+pillow = ">=6.2.0"
+pyparsing = ">=2.2.1"
+python-dateutil = ">=2.7"
+
+[[package]]
 name = "mccabe"
 version = "0.6.1"
 description = "McCabe checker, plugin for flake8"
@@ -330,6 +365,14 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "numpy"
+version = "1.21.0"
+description = "NumPy is the fundamental package for array computing with Python."
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[[package]]
 name = "pathspec"
 version = "0.8.1"
 description = "Utility library for gitignore style pattern matching of file paths."
@@ -347,6 +390,14 @@ python-versions = "*"
 
 [package.dependencies]
 flake8-polyfill = ">=1.0.2,<2"
+
+[[package]]
+name = "pillow"
+version = "8.2.0"
+description = "Python Imaging Library (Fork)"
+category = "main"
+optional = false
+python-versions = ">=3.6"
 
 [[package]]
 name = "pre-commit"
@@ -393,6 +444,14 @@ description = "passive checker of Python programs"
 category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[[package]]
+name = "pyparsing"
+version = "2.4.7"
+description = "Python parsing module"
+category = "main"
+optional = false
+python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
 name = "python-dateutil"
@@ -536,7 +595,7 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "fa129ee58b02d7a756ae0928c83fb09d6bb4b38686f5fa5c53bd1d79c67ec80d"
+content-hash = "cbf3854e9776fb65c59ec70ccdf2bd72b0ca3dafae7e3b2cca38ab690e4219c0"
 
 [metadata.files]
 aiohttp = [
@@ -627,6 +686,10 @@ colorama = [
     {file = "colorama-0.4.4-py2.py3-none-any.whl", hash = "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"},
     {file = "colorama-0.4.4.tar.gz", hash = "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b"},
 ]
+cycler = [
+    {file = "cycler-0.10.0-py2.py3-none-any.whl", hash = "sha256:1d8a5ae1ff6c5cf9b93e8811e581232ad8920aeec647c37316ceac982b08cb2d"},
+    {file = "cycler-0.10.0.tar.gz", hash = "sha256:cd7b2d1018258d7247a71425e9f26463dfb444d411c39569972f4ce586b0c9d8"},
+]
 discord-py-slash-command = [
     {file = "discord-py-slash-command-1.2.2.tar.gz", hash = "sha256:192b4454bb5ca9e6032812a4142469782ab7a8a4f93c13fb04bb5a2ff100ddfb"},
     {file = "discord_py_slash_command-1.2.2-py3-none-any.whl", hash = "sha256:5539b931af40b3bc91ee0a8ed1e97a58400c442ef542007db9dda315dce90144"},
@@ -681,6 +744,61 @@ isort = [
     {file = "isort-4.3.21-py2.py3-none-any.whl", hash = "sha256:6e811fcb295968434526407adb8796944f1988c5b65e8139058f2014cbe100fd"},
     {file = "isort-4.3.21.tar.gz", hash = "sha256:54da7e92468955c4fceacd0c86bd0ec997b0e1ee80d97f67c35a78b719dccab1"},
 ]
+kiwisolver = [
+    {file = "kiwisolver-1.3.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:fd34fbbfbc40628200730bc1febe30631347103fc8d3d4fa012c21ab9c11eca9"},
+    {file = "kiwisolver-1.3.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:d3155d828dec1d43283bd24d3d3e0d9c7c350cdfcc0bd06c0ad1209c1bbc36d0"},
+    {file = "kiwisolver-1.3.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:5a7a7dbff17e66fac9142ae2ecafb719393aaee6a3768c9de2fd425c63b53e21"},
+    {file = "kiwisolver-1.3.1-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:f8d6f8db88049a699817fd9178782867bf22283e3813064302ac59f61d95be05"},
+    {file = "kiwisolver-1.3.1-cp36-cp36m-manylinux2014_ppc64le.whl", hash = "sha256:5f6ccd3dd0b9739edcf407514016108e2280769c73a85b9e59aa390046dbf08b"},
+    {file = "kiwisolver-1.3.1-cp36-cp36m-win32.whl", hash = "sha256:225e2e18f271e0ed8157d7f4518ffbf99b9450fca398d561eb5c4a87d0986dd9"},
+    {file = "kiwisolver-1.3.1-cp36-cp36m-win_amd64.whl", hash = "sha256:cf8b574c7b9aa060c62116d4181f3a1a4e821b2ec5cbfe3775809474113748d4"},
+    {file = "kiwisolver-1.3.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:232c9e11fd7ac3a470d65cd67e4359eee155ec57e822e5220322d7b2ac84fbf0"},
+    {file = "kiwisolver-1.3.1-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:b38694dcdac990a743aa654037ff1188c7a9801ac3ccc548d3341014bc5ca278"},
+    {file = "kiwisolver-1.3.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:ca3820eb7f7faf7f0aa88de0e54681bddcb46e485beb844fcecbcd1c8bd01689"},
+    {file = "kiwisolver-1.3.1-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:c8fd0f1ae9d92b42854b2979024d7597685ce4ada367172ed7c09edf2cef9cb8"},
+    {file = "kiwisolver-1.3.1-cp37-cp37m-manylinux2014_ppc64le.whl", hash = "sha256:1e1bc12fb773a7b2ffdeb8380609f4f8064777877b2225dec3da711b421fda31"},
+    {file = "kiwisolver-1.3.1-cp37-cp37m-win32.whl", hash = "sha256:72c99e39d005b793fb7d3d4e660aed6b6281b502e8c1eaf8ee8346023c8e03bc"},
+    {file = "kiwisolver-1.3.1-cp37-cp37m-win_amd64.whl", hash = "sha256:8be8d84b7d4f2ba4ffff3665bcd0211318aa632395a1a41553250484a871d454"},
+    {file = "kiwisolver-1.3.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:31dfd2ac56edc0ff9ac295193eeaea1c0c923c0355bf948fbd99ed6018010b72"},
+    {file = "kiwisolver-1.3.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:563c649cfdef27d081c84e72a03b48ea9408c16657500c312575ae9d9f7bc1c3"},
+    {file = "kiwisolver-1.3.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:78751b33595f7f9511952e7e60ce858c6d64db2e062afb325985ddbd34b5c131"},
+    {file = "kiwisolver-1.3.1-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:a357fd4f15ee49b4a98b44ec23a34a95f1e00292a139d6015c11f55774ef10de"},
+    {file = "kiwisolver-1.3.1-cp38-cp38-manylinux2014_ppc64le.whl", hash = "sha256:5989db3b3b34b76c09253deeaf7fbc2707616f130e166996606c284395da3f18"},
+    {file = "kiwisolver-1.3.1-cp38-cp38-win32.whl", hash = "sha256:c08e95114951dc2090c4a630c2385bef681cacf12636fb0241accdc6b303fd81"},
+    {file = "kiwisolver-1.3.1-cp38-cp38-win_amd64.whl", hash = "sha256:44a62e24d9b01ba94ae7a4a6c3fb215dc4af1dde817e7498d901e229aaf50e4e"},
+    {file = "kiwisolver-1.3.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:50af681a36b2a1dee1d3c169ade9fdc59207d3c31e522519181e12f1b3ba7000"},
+    {file = "kiwisolver-1.3.1-cp39-cp39-manylinux1_i686.whl", hash = "sha256:a53d27d0c2a0ebd07e395e56a1fbdf75ffedc4a05943daf472af163413ce9598"},
+    {file = "kiwisolver-1.3.1-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:834ee27348c4aefc20b479335fd422a2c69db55f7d9ab61721ac8cd83eb78882"},
+    {file = "kiwisolver-1.3.1-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:5c3e6455341008a054cccee8c5d24481bcfe1acdbc9add30aa95798e95c65621"},
+    {file = "kiwisolver-1.3.1-cp39-cp39-manylinux2014_ppc64le.whl", hash = "sha256:acef3d59d47dd85ecf909c359d0fd2c81ed33bdff70216d3956b463e12c38a54"},
+    {file = "kiwisolver-1.3.1-cp39-cp39-win32.whl", hash = "sha256:c5518d51a0735b1e6cee1fdce66359f8d2b59c3ca85dc2b0813a8aa86818a030"},
+    {file = "kiwisolver-1.3.1-cp39-cp39-win_amd64.whl", hash = "sha256:b9edd0110a77fc321ab090aaa1cfcaba1d8499850a12848b81be2222eab648f6"},
+    {file = "kiwisolver-1.3.1-pp36-pypy36_pp73-macosx_10_9_x86_64.whl", hash = "sha256:0cd53f403202159b44528498de18f9285b04482bab2a6fc3f5dd8dbb9352e30d"},
+    {file = "kiwisolver-1.3.1-pp36-pypy36_pp73-manylinux2010_x86_64.whl", hash = "sha256:33449715e0101e4d34f64990352bce4095c8bf13bed1b390773fc0a7295967b3"},
+    {file = "kiwisolver-1.3.1-pp36-pypy36_pp73-win32.whl", hash = "sha256:401a2e9afa8588589775fe34fc22d918ae839aaaf0c0e96441c0fdbce6d8ebe6"},
+    {file = "kiwisolver-1.3.1.tar.gz", hash = "sha256:950a199911a8d94683a6b10321f9345d5a3a8433ec58b217ace979e18f16e248"},
+]
+matplotlib = [
+    {file = "matplotlib-3.4.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:c541ee5a3287efe066bbe358320853cf4916bc14c00c38f8f3d8d75275a405a9"},
+    {file = "matplotlib-3.4.2-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:3a5c18dbd2c7c366da26a4ad1462fe3e03a577b39e3b503bbcf482b9cdac093c"},
+    {file = "matplotlib-3.4.2-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:a9d8cb5329df13e0cdaa14b3b43f47b5e593ec637f13f14db75bb16e46178b05"},
+    {file = "matplotlib-3.4.2-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:7ad19f3fb6145b9eb41c08e7cbb9f8e10b91291396bee21e9ce761bb78df63ec"},
+    {file = "matplotlib-3.4.2-cp37-cp37m-win32.whl", hash = "sha256:7a58f3d8fe8fac3be522c79d921c9b86e090a59637cb88e3bc51298d7a2c862a"},
+    {file = "matplotlib-3.4.2-cp37-cp37m-win_amd64.whl", hash = "sha256:6382bc6e2d7e481bcd977eb131c31dee96e0fb4f9177d15ec6fb976d3b9ace1a"},
+    {file = "matplotlib-3.4.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:6a6a44f27aabe720ec4fd485061e8a35784c2b9ffa6363ad546316dfc9cea04e"},
+    {file = "matplotlib-3.4.2-cp38-cp38-manylinux1_i686.whl", hash = "sha256:1c1779f7ab7d8bdb7d4c605e6ffaa0614b3e80f1e3c8ccf7b9269a22dbc5986b"},
+    {file = "matplotlib-3.4.2-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:5826f56055b9b1c80fef82e326097e34dc4af8c7249226b7dd63095a686177d1"},
+    {file = "matplotlib-3.4.2-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:0bea5ec5c28d49020e5d7923c2725b837e60bc8be99d3164af410eb4b4c827da"},
+    {file = "matplotlib-3.4.2-cp38-cp38-win32.whl", hash = "sha256:6475d0209024a77f869163ec3657c47fed35d9b6ed8bccba8aa0f0099fbbdaa8"},
+    {file = "matplotlib-3.4.2-cp38-cp38-win_amd64.whl", hash = "sha256:21b31057bbc5e75b08e70a43cefc4c0b2c2f1b1a850f4a0f7af044eb4163086c"},
+    {file = "matplotlib-3.4.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:b26535b9de85326e6958cdef720ecd10bcf74a3f4371bf9a7e5b2e659c17e153"},
+    {file = "matplotlib-3.4.2-cp39-cp39-manylinux1_i686.whl", hash = "sha256:32fa638cc10886885d1ca3d409d4473d6a22f7ceecd11322150961a70fab66dd"},
+    {file = "matplotlib-3.4.2-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:956c8849b134b4a343598305a3ca1bdd3094f01f5efc8afccdebeffe6b315247"},
+    {file = "matplotlib-3.4.2-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:85f191bb03cb1a7b04b5c2cca4792bef94df06ef473bc49e2818105671766fee"},
+    {file = "matplotlib-3.4.2-cp39-cp39-win32.whl", hash = "sha256:b1d5a2cedf5de05567c441b3a8c2651fbde56df08b82640e7f06c8cd91e201f6"},
+    {file = "matplotlib-3.4.2-cp39-cp39-win_amd64.whl", hash = "sha256:df815378a754a7edd4559f8c51fc7064f779a74013644a7f5ac7a0c31f875866"},
+    {file = "matplotlib-3.4.2.tar.gz", hash = "sha256:d8d994cefdff9aaba45166eb3de4f5211adb4accac85cbf97137e98f26ea0219"},
+]
 mccabe = [
     {file = "mccabe-0.6.1-py2.py3-none-any.whl", hash = "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42"},
     {file = "mccabe-0.6.1.tar.gz", hash = "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"},
@@ -728,6 +846,36 @@ nodeenv = [
     {file = "nodeenv-1.6.0-py2.py3-none-any.whl", hash = "sha256:621e6b7076565ddcacd2db0294c0381e01fd28945ab36bcf00f41c5daf63bef7"},
     {file = "nodeenv-1.6.0.tar.gz", hash = "sha256:3ef13ff90291ba2a4a7a4ff9a979b63ffdd00a464dbe04acf0ea6471517a4c2b"},
 ]
+numpy = [
+    {file = "numpy-1.21.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:d5caa946a9f55511e76446e170bdad1d12d6b54e17a2afe7b189112ed4412bb8"},
+    {file = "numpy-1.21.0-cp37-cp37m-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:ac4fd578322842dbda8d968e3962e9f22e862b6ec6e3378e7415625915e2da4d"},
+    {file = "numpy-1.21.0-cp37-cp37m-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:598fe100b2948465cf3ed64b1a326424b5e4be2670552066e17dfaa67246011d"},
+    {file = "numpy-1.21.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7c55407f739f0bfcec67d0df49103f9333edc870061358ac8a8c9e37ea02fcd2"},
+    {file = "numpy-1.21.0-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:75579acbadbf74e3afd1153da6177f846212ea2a0cc77de53523ae02c9256513"},
+    {file = "numpy-1.21.0-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:cc367c86eb87e5b7c9592935620f22d13b090c609f1b27e49600cd033b529f54"},
+    {file = "numpy-1.21.0-cp37-cp37m-win32.whl", hash = "sha256:d89b0dc7f005090e32bb4f9bf796e1dcca6b52243caf1803fdd2b748d8561f63"},
+    {file = "numpy-1.21.0-cp37-cp37m-win_amd64.whl", hash = "sha256:eda2829af498946c59d8585a9fd74da3f810866e05f8df03a86f70079c7531dd"},
+    {file = "numpy-1.21.0-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:1a784e8ff7ea2a32e393cc53eb0003eca1597c7ca628227e34ce34eb11645a0e"},
+    {file = "numpy-1.21.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:bba474a87496d96e61461f7306fba2ebba127bed7836212c360f144d1e72ac54"},
+    {file = "numpy-1.21.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:fd0a359c1c17f00cb37de2969984a74320970e0ceef4808c32e00773b06649d9"},
+    {file = "numpy-1.21.0-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:e4d5a86a5257843a18fb1220c5f1c199532bc5d24e849ed4b0289fb59fbd4d8f"},
+    {file = "numpy-1.21.0-cp38-cp38-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:620732f42259eb2c4642761bd324462a01cdd13dd111740ce3d344992dd8492f"},
+    {file = "numpy-1.21.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b9205711e5440954f861ceeea8f1b415d7dd15214add2e878b4d1cf2bcb1a914"},
+    {file = "numpy-1.21.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ad09f55cc95ed8d80d8ab2052f78cc21cb231764de73e229140d81ff49d8145e"},
+    {file = "numpy-1.21.0-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:a1f2fb2da242568af0271455b89aee0f71e4e032086ee2b4c5098945d0e11cf6"},
+    {file = "numpy-1.21.0-cp38-cp38-win32.whl", hash = "sha256:e58ddb53a7b4959932f5582ac455ff90dcb05fac3f8dcc8079498d43afbbde6c"},
+    {file = "numpy-1.21.0-cp38-cp38-win_amd64.whl", hash = "sha256:d2910d0a075caed95de1a605df00ee03b599de5419d0b95d55342e9a33ad1fb3"},
+    {file = "numpy-1.21.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:a290989cd671cd0605e9c91a70e6df660f73ae87484218e8285c6522d29f6e38"},
+    {file = "numpy-1.21.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:3537b967b350ad17633b35c2f4b1a1bbd258c018910b518c30b48c8e41272717"},
+    {file = "numpy-1.21.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:ccc6c650f8700ce1e3a77668bb7c43e45c20ac06ae00d22bdf6760b38958c883"},
+    {file = "numpy-1.21.0-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:709884863def34d72b183d074d8ba5cfe042bc3ff8898f1ffad0209161caaa99"},
+    {file = "numpy-1.21.0-cp39-cp39-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:bebab3eaf0641bba26039fb0b2c5bf9b99407924b53b1ea86e03c32c64ef5aef"},
+    {file = "numpy-1.21.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cf680682ad0a3bef56dae200dbcbac2d57294a73e5b0f9864955e7dd7c2c2491"},
+    {file = "numpy-1.21.0-cp39-cp39-win32.whl", hash = "sha256:d95d16204cd51ff1a1c8d5f9958ce90ae190be81d348b514f9be39f878b8044a"},
+    {file = "numpy-1.21.0-cp39-cp39-win_amd64.whl", hash = "sha256:2ba579dde0563f47021dcd652253103d6fd66165b18011dce1a0609215b2791e"},
+    {file = "numpy-1.21.0-pp37-pypy37_pp73-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:3c40e6b860220ed862e8097b8f81c9af6d7405b723f4a7af24a267b46f90e461"},
+    {file = "numpy-1.21.0.zip", hash = "sha256:e80fe25cba41c124d04c662f33f6364909b985f2eb5998aaa5ae4b9587242cce"},
+]
 pathspec = [
     {file = "pathspec-0.8.1-py2.py3-none-any.whl", hash = "sha256:aa0cb481c4041bf52ffa7b0d8fa6cd3e88a2ca4879c533c9153882ee2556790d"},
     {file = "pathspec-0.8.1.tar.gz", hash = "sha256:86379d6b86d75816baba717e64b1a3a3469deb93bb76d613c9ce79edc5cb68fd"},
@@ -735,6 +883,42 @@ pathspec = [
 pep8-naming = [
     {file = "pep8-naming-0.9.1.tar.gz", hash = "sha256:a33d38177056321a167decd6ba70b890856ba5025f0a8eca6a3eda607da93caf"},
     {file = "pep8_naming-0.9.1-py2.py3-none-any.whl", hash = "sha256:45f330db8fcfb0fba57458c77385e288e7a3be1d01e8ea4268263ef677ceea5f"},
+]
+pillow = [
+    {file = "Pillow-8.2.0-cp36-cp36m-macosx_10_10_x86_64.whl", hash = "sha256:dc38f57d8f20f06dd7c3161c59ca2c86893632623f33a42d592f097b00f720a9"},
+    {file = "Pillow-8.2.0-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:a013cbe25d20c2e0c4e85a9daf438f85121a4d0344ddc76e33fd7e3965d9af4b"},
+    {file = "Pillow-8.2.0-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:8bb1e155a74e1bfbacd84555ea62fa21c58e0b4e7e6b20e4447b8d07990ac78b"},
+    {file = "Pillow-8.2.0-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:c5236606e8570542ed424849f7852a0ff0bce2c4c8d0ba05cc202a5a9c97dee9"},
+    {file = "Pillow-8.2.0-cp36-cp36m-win32.whl", hash = "sha256:12e5e7471f9b637762453da74e390e56cc43e486a88289995c1f4c1dc0bfe727"},
+    {file = "Pillow-8.2.0-cp36-cp36m-win_amd64.whl", hash = "sha256:5afe6b237a0b81bd54b53f835a153770802f164c5570bab5e005aad693dab87f"},
+    {file = "Pillow-8.2.0-cp37-cp37m-macosx_10_10_x86_64.whl", hash = "sha256:cb7a09e173903541fa888ba010c345893cd9fc1b5891aaf060f6ca77b6a3722d"},
+    {file = "Pillow-8.2.0-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:0d19d70ee7c2ba97631bae1e7d4725cdb2ecf238178096e8c82ee481e189168a"},
+    {file = "Pillow-8.2.0-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:083781abd261bdabf090ad07bb69f8f5599943ddb539d64497ed021b2a67e5a9"},
+    {file = "Pillow-8.2.0-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:c6b39294464b03457f9064e98c124e09008b35a62e3189d3513e5148611c9388"},
+    {file = "Pillow-8.2.0-cp37-cp37m-win32.whl", hash = "sha256:01425106e4e8cee195a411f729cff2a7d61813b0b11737c12bd5991f5f14bcd5"},
+    {file = "Pillow-8.2.0-cp37-cp37m-win_amd64.whl", hash = "sha256:3b570f84a6161cf8865c4e08adf629441f56e32f180f7aa4ccbd2e0a5a02cba2"},
+    {file = "Pillow-8.2.0-cp38-cp38-macosx_10_10_x86_64.whl", hash = "sha256:031a6c88c77d08aab84fecc05c3cde8414cd6f8406f4d2b16fed1e97634cc8a4"},
+    {file = "Pillow-8.2.0-cp38-cp38-manylinux1_i686.whl", hash = "sha256:66cc56579fd91f517290ab02c51e3a80f581aba45fd924fcdee01fa06e635812"},
+    {file = "Pillow-8.2.0-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:6c32cc3145928c4305d142ebec682419a6c0a8ce9e33db900027ddca1ec39178"},
+    {file = "Pillow-8.2.0-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:624b977355cde8b065f6d51b98497d6cd5fbdd4f36405f7a8790e3376125e2bb"},
+    {file = "Pillow-8.2.0-cp38-cp38-win32.whl", hash = "sha256:5cbf3e3b1014dddc45496e8cf38b9f099c95a326275885199f427825c6522232"},
+    {file = "Pillow-8.2.0-cp38-cp38-win_amd64.whl", hash = "sha256:463822e2f0d81459e113372a168f2ff59723e78528f91f0bd25680ac185cf797"},
+    {file = "Pillow-8.2.0-cp39-cp39-macosx_10_10_x86_64.whl", hash = "sha256:95d5ef984eff897850f3a83883363da64aae1000e79cb3c321915468e8c6add5"},
+    {file = "Pillow-8.2.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:b91c36492a4bbb1ee855b7d16fe51379e5f96b85692dc8210831fbb24c43e484"},
+    {file = "Pillow-8.2.0-cp39-cp39-manylinux1_i686.whl", hash = "sha256:d68cb92c408261f806b15923834203f024110a2e2872ecb0bd2a110f89d3c602"},
+    {file = "Pillow-8.2.0-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:f217c3954ce5fd88303fc0c317af55d5e0204106d86dea17eb8205700d47dec2"},
+    {file = "Pillow-8.2.0-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:5b70110acb39f3aff6b74cf09bb4169b167e2660dabc304c1e25b6555fa781ef"},
+    {file = "Pillow-8.2.0-cp39-cp39-win32.whl", hash = "sha256:a7d5e9fad90eff8f6f6106d3b98b553a88b6f976e51fce287192a5d2d5363713"},
+    {file = "Pillow-8.2.0-cp39-cp39-win_amd64.whl", hash = "sha256:238c197fc275b475e87c1453b05b467d2d02c2915fdfdd4af126145ff2e4610c"},
+    {file = "Pillow-8.2.0-pp36-pypy36_pp73-macosx_10_10_x86_64.whl", hash = "sha256:0e04d61f0064b545b989126197930807c86bcbd4534d39168f4aa5fda39bb8f9"},
+    {file = "Pillow-8.2.0-pp36-pypy36_pp73-manylinux2010_i686.whl", hash = "sha256:63728564c1410d99e6d1ae8e3b810fe012bc440952168af0a2877e8ff5ab96b9"},
+    {file = "Pillow-8.2.0-pp36-pypy36_pp73-manylinux2010_x86_64.whl", hash = "sha256:c03c07ed32c5324939b19e36ae5f75c660c81461e312a41aea30acdd46f93a7c"},
+    {file = "Pillow-8.2.0-pp37-pypy37_pp73-macosx_10_10_x86_64.whl", hash = "sha256:4d98abdd6b1e3bf1a1cbb14c3895226816e666749ac040c4e2554231068c639b"},
+    {file = "Pillow-8.2.0-pp37-pypy37_pp73-manylinux2010_i686.whl", hash = "sha256:aac00e4bc94d1b7813fe882c28990c1bc2f9d0e1aa765a5f2b516e8a6a16a9e4"},
+    {file = "Pillow-8.2.0-pp37-pypy37_pp73-manylinux2010_x86_64.whl", hash = "sha256:22fd0f42ad15dfdde6c581347eaa4adb9a6fc4b865f90b23378aa7914895e120"},
+    {file = "Pillow-8.2.0-pp37-pypy37_pp73-win32.whl", hash = "sha256:e98eca29a05913e82177b3ba3d198b1728e164869c613d76d0de4bde6768a50e"},
+    {file = "Pillow-8.2.0-pp37-pypy37_pp73-win_amd64.whl", hash = "sha256:8b56553c0345ad6dcb2e9b433ae47d67f95fc23fe28a0bde15a120f25257e291"},
+    {file = "Pillow-8.2.0.tar.gz", hash = "sha256:a787ab10d7bb5494e5f76536ac460741788f1fbce851068d73a87ca7c35fc3e1"},
 ]
 pre-commit = [
     {file = "pre_commit-2.13.0-py2.py3-none-any.whl", hash = "sha256:b679d0fddd5b9d6d98783ae5f10fd0c4c59954f375b70a58cbe1ce9bcf9809a4"},
@@ -751,6 +935,10 @@ pydocstyle = [
 pyflakes = [
     {file = "pyflakes-2.3.1-py2.py3-none-any.whl", hash = "sha256:7893783d01b8a89811dd72d7dfd4d84ff098e5eed95cfa8905b22bbffe52efc3"},
     {file = "pyflakes-2.3.1.tar.gz", hash = "sha256:f5bc8ecabc05bb9d291eb5203d6810b49040f6ff446a756326104746cc00c1db"},
+]
+pyparsing = [
+    {file = "pyparsing-2.4.7-py2.py3-none-any.whl", hash = "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"},
+    {file = "pyparsing-2.4.7.tar.gz", hash = "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1"},
 ]
 python-dateutil = [
     {file = "python-dateutil-2.8.1.tar.gz", hash = "sha256:73ebfe9dbf22e832286dafa60473e4cd239f8592f699aa5adaf10050e6e1823c"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -373,6 +373,22 @@ optional = false
 python-versions = ">=3.7"
 
 [[package]]
+name = "pandas"
+version = "1.2.5"
+description = "Powerful data structures for data analysis, time series, and statistics"
+category = "main"
+optional = false
+python-versions = ">=3.7.1"
+
+[package.dependencies]
+numpy = ">=1.16.5"
+python-dateutil = ">=2.7.3"
+pytz = ">=2017.3"
+
+[package.extras]
+test = ["pytest (>=5.0.1)", "pytest-xdist", "hypothesis (>=3.58)"]
+
+[[package]]
 name = "pathspec"
 version = "0.8.1"
 description = "Utility library for gitignore style pattern matching of file paths."
@@ -465,6 +481,14 @@ python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
 six = ">=1.5"
 
 [[package]]
+name = "pytz"
+version = "2021.1"
+description = "World timezone definitions, modern and historical"
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "pyyaml"
 version = "5.4.1"
 description = "YAML parser and emitter for Python"
@@ -497,6 +521,31 @@ urllib3 = ">=1.21.1,<1.27"
 [package.extras]
 security = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)"]
 socks = ["PySocks (>=1.5.6,!=1.5.7)", "win-inet-pton"]
+
+[[package]]
+name = "scipy"
+version = "1.6.1"
+description = "SciPy: Scientific Library for Python"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+numpy = ">=1.16.5"
+
+[[package]]
+name = "seaborn"
+version = "0.11.1"
+description = "seaborn: statistical data visualization"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+matplotlib = ">=2.2"
+numpy = ">=1.15"
+pandas = ">=0.23"
+scipy = ">=1.0"
 
 [[package]]
 name = "seed-isort-config"
@@ -595,7 +644,7 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "cbf3854e9776fb65c59ec70ccdf2bd72b0ca3dafae7e3b2cca38ab690e4219c0"
+content-hash = "e946411a288ec0ebf17d5ce787093381302b1681ad580d3bcaa61ddb05f0f4bd"
 
 [metadata.files]
 aiohttp = [
@@ -876,6 +925,26 @@ numpy = [
     {file = "numpy-1.21.0-pp37-pypy37_pp73-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:3c40e6b860220ed862e8097b8f81c9af6d7405b723f4a7af24a267b46f90e461"},
     {file = "numpy-1.21.0.zip", hash = "sha256:e80fe25cba41c124d04c662f33f6364909b985f2eb5998aaa5ae4b9587242cce"},
 ]
+pandas = [
+    {file = "pandas-1.2.5-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:1102d719038e134e648e7920672188a00375f3908f0383fd3b202fbb9d2c3a95"},
+    {file = "pandas-1.2.5-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:38e7486410de23069392bdf1dc7297ae75d2d67531750753f3149c871cd1c6e3"},
+    {file = "pandas-1.2.5-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:94ca6ea3f46f44a979a38a4d5a70a88cee734f7248d7aeeed202e6b3ba485af1"},
+    {file = "pandas-1.2.5-cp37-cp37m-win32.whl", hash = "sha256:821d92466fcd2826656374a9b6fe4f2ec2ba5e370cce71d5a990577929d948df"},
+    {file = "pandas-1.2.5-cp37-cp37m-win_amd64.whl", hash = "sha256:0dbd125b0e44e5068163cbc9080a00db1756a5e36309329ae14fd259747f2300"},
+    {file = "pandas-1.2.5-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:7b09293c7119ab22ab3f7f086f813ac2acbfa3bcaaaeb650f4cddfb5b9fa9be4"},
+    {file = "pandas-1.2.5-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fc9215dd1dd836ff26b896654e66b2dfcf4bbb18aa4c1089a79bab527b665a90"},
+    {file = "pandas-1.2.5-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:e36515163829e0e95a6af10820f178dd8768102482c01872bff8ae592e508e58"},
+    {file = "pandas-1.2.5-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:0c34b89215f984a9e4956446e0a29330d720085efa08ea72022387ee37d8b373"},
+    {file = "pandas-1.2.5-cp38-cp38-win32.whl", hash = "sha256:f20e4b8a7909f5a0c0a9e745091e3ea18b45af9f73496a4d498688badbdac7ea"},
+    {file = "pandas-1.2.5-cp38-cp38-win_amd64.whl", hash = "sha256:9244fb0904512b074d8c6362fb13aac1da6c4db94372760ddb2565c620240264"},
+    {file = "pandas-1.2.5-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:c862cd72353921c102166784fc4db749f1c3b691dd017fc36d9df2c67a9afe4e"},
+    {file = "pandas-1.2.5-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d9e6edddeac9a8e473391d2d2067bb3c9dc7ad79fd137af26a39ee425c2b4c78"},
+    {file = "pandas-1.2.5-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a67227e17236442c6bc31c02cb713b5277b26eee204eac14b5aecba52492e3a3"},
+    {file = "pandas-1.2.5-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:4bfbf62b00460f78a8bc4407112965c5ab44324f34551e8e1f4cac271a07706c"},
+    {file = "pandas-1.2.5-cp39-cp39-win32.whl", hash = "sha256:25fc8ef6c6beb51c9224284a1ad89dfb591832f23ceff78845f182de35c52356"},
+    {file = "pandas-1.2.5-cp39-cp39-win_amd64.whl", hash = "sha256:78de96c1174bcfdbe8dece9c38c2d7994e407fd8bb62146bb46c61294bcc06ef"},
+    {file = "pandas-1.2.5.tar.gz", hash = "sha256:14abb8ea73fce8aebbb1fb44bec809163f1c55241bcc1db91c2c780e97265033"},
+]
 pathspec = [
     {file = "pathspec-0.8.1-py2.py3-none-any.whl", hash = "sha256:aa0cb481c4041bf52ffa7b0d8fa6cd3e88a2ca4879c533c9153882ee2556790d"},
     {file = "pathspec-0.8.1.tar.gz", hash = "sha256:86379d6b86d75816baba717e64b1a3a3469deb93bb76d613c9ce79edc5cb68fd"},
@@ -943,6 +1012,10 @@ pyparsing = [
 python-dateutil = [
     {file = "python-dateutil-2.8.1.tar.gz", hash = "sha256:73ebfe9dbf22e832286dafa60473e4cd239f8592f699aa5adaf10050e6e1823c"},
     {file = "python_dateutil-2.8.1-py2.py3-none-any.whl", hash = "sha256:75bb3f31ea686f1197762692a9ee6a7550b59fc6ca3a1f4b5d7e32fb98e2da2a"},
+]
+pytz = [
+    {file = "pytz-2021.1-py2.py3-none-any.whl", hash = "sha256:eb10ce3e7736052ed3623d49975ce333bcd712c7bb19a58b9e2089d4057d0798"},
+    {file = "pytz-2021.1.tar.gz", hash = "sha256:83a4a90894bf38e243cf052c8b58f381bfe9a7a483f6a9cab140bc7f702ac4da"},
 ]
 pyyaml = [
     {file = "PyYAML-5.4.1-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:3b2b1824fe7112845700f815ff6a489360226a5609b96ec2190a45e62a9fc922"},
@@ -1021,6 +1094,31 @@ regex = [
 requests = [
     {file = "requests-2.25.1-py2.py3-none-any.whl", hash = "sha256:c210084e36a42ae6b9219e00e48287def368a26d03a048ddad7bfee44f75871e"},
     {file = "requests-2.25.1.tar.gz", hash = "sha256:27973dd4a904a4f13b263a19c866c13b92a39ed1c964655f025f3f8d3d75b804"},
+]
+scipy = [
+    {file = "scipy-1.6.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:a15a1f3fc0abff33e792d6049161b7795909b40b97c6cc2934ed54384017ab76"},
+    {file = "scipy-1.6.1-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:e79570979ccdc3d165456dd62041d9556fb9733b86b4b6d818af7a0afc15f092"},
+    {file = "scipy-1.6.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:a423533c55fec61456dedee7b6ee7dce0bb6bfa395424ea374d25afa262be261"},
+    {file = "scipy-1.6.1-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:33d6b7df40d197bdd3049d64e8e680227151673465e5d85723b3b8f6b15a6ced"},
+    {file = "scipy-1.6.1-cp37-cp37m-win32.whl", hash = "sha256:6725e3fbb47da428794f243864f2297462e9ee448297c93ed1dcbc44335feb78"},
+    {file = "scipy-1.6.1-cp37-cp37m-win_amd64.whl", hash = "sha256:5fa9c6530b1661f1370bcd332a1e62ca7881785cc0f80c0d559b636567fab63c"},
+    {file = "scipy-1.6.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:bd50daf727f7c195e26f27467c85ce653d41df4358a25b32434a50d8870fc519"},
+    {file = "scipy-1.6.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:f46dd15335e8a320b0fb4685f58b7471702234cba8bb3442b69a3e1dc329c345"},
+    {file = "scipy-1.6.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:0e5b0ccf63155d90da576edd2768b66fb276446c371b73841e3503be1d63fb5d"},
+    {file = "scipy-1.6.1-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:2481efbb3740977e3c831edfd0bd9867be26387cacf24eb5e366a6a374d3d00d"},
+    {file = "scipy-1.6.1-cp38-cp38-win32.whl", hash = "sha256:68cb4c424112cd4be886b4d979c5497fba190714085f46b8ae67a5e4416c32b4"},
+    {file = "scipy-1.6.1-cp38-cp38-win_amd64.whl", hash = "sha256:5f331eeed0297232d2e6eea51b54e8278ed8bb10b099f69c44e2558c090d06bf"},
+    {file = "scipy-1.6.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:0c8a51d33556bf70367452d4d601d1742c0e806cd0194785914daf19775f0e67"},
+    {file = "scipy-1.6.1-cp39-cp39-manylinux1_i686.whl", hash = "sha256:83bf7c16245c15bc58ee76c5418e46ea1811edcc2e2b03041b804e46084ab627"},
+    {file = "scipy-1.6.1-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:794e768cc5f779736593046c9714e0f3a5940bc6dcc1dba885ad64cbfb28e9f0"},
+    {file = "scipy-1.6.1-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:5da5471aed911fe7e52b86bf9ea32fb55ae93e2f0fac66c32e58897cfb02fa07"},
+    {file = "scipy-1.6.1-cp39-cp39-win32.whl", hash = "sha256:8e403a337749ed40af60e537cc4d4c03febddcc56cd26e774c9b1b600a70d3e4"},
+    {file = "scipy-1.6.1-cp39-cp39-win_amd64.whl", hash = "sha256:a5193a098ae9f29af283dcf0041f762601faf2e595c0db1da929875b7570353f"},
+    {file = "scipy-1.6.1.tar.gz", hash = "sha256:c4fceb864890b6168e79b0e714c585dbe2fd4222768ee90bc1aa0f8218691b11"},
+]
+seaborn = [
+    {file = "seaborn-0.11.1-py3-none-any.whl", hash = "sha256:4e1cce9489449a1c6ff3c567f2113cdb41122f727e27a984950d004a88ef3c5c"},
+    {file = "seaborn-0.11.1.tar.gz", hash = "sha256:44e78eaed937c5a87fc7a892c329a7cc091060b67ebd1d0d306b446a74ba01ad"},
 ]
 seed-isort-config = [
     {file = "seed_isort_config-2.2.0-py2.py3-none-any.whl", hash = "sha256:8601fb715a5a4aac39256bbf73c2da6a81f964da9c9d9897ab9074db3663526f"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ blossom-wrapper = { git = "https://github.com/GrafeasGroup/blossom-wrapper.git",
 requests = "^2.25.1"
 PyYAML = "^5.3.1"
 python-dateutil = "^2.8.1"
+matplotlib = "^3.4.2"
 
 [tool.poetry.dev-dependencies]
 better-exceptions = "^0.2.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,8 @@ requests = "^2.25.1"
 PyYAML = "^5.3.1"
 python-dateutil = "^2.8.1"
 matplotlib = "^3.4.2"
+pandas = "^1.2.5"
+seaborn = "^0.11.1"
 
 [tool.poetry.dev-dependencies]
 better-exceptions = "^0.2.2"


### PR DESCRIPTION
Relevant issue: Closes #29.

## Description:

Adds a `/heatmap` command to display the activity heatmap of the given user.
The output looks like this:
![Output of the `/heatmap` command](https://user-images.githubusercontent.com/13908946/123277392-59ea9d00-d506-11eb-9048-a93666ba717c.png)
The image can be clicked for a larger view of the heatmap.

Please note that the current data is mostly incorrect because most dates in Blossom are still wrong (see GrafeasGroup/blossom#157).

## Checklist:

- [x] Code Quality
- [x] Pep-8
- [ ] Tests (if applicable)
- [x] Success Criteria Met
- [x] Inline Documentation
- [ ] Wiki Documentation (if applicable)
