### PR TITLE
Add `/pirules` command

### DIFF
--- a/buttercup/cogs/helpers.py
+++ b/buttercup/cogs/helpers.py
@@ -21,6 +21,15 @@ def extract_username(display_name: str) -> str:
     return match.group("username")
 
 
+def extract_sub_name(subreddit: str) -> str:
+    """Extract the name of the sub without prefix."""
+    if subreddit.startswith("/r/"):
+        return subreddit[3:]
+    if subreddit.startswith("r/"):
+        return subreddit[2:]
+    return subreddit
+
+
 def extract_utc_offset(display_name: str) -> int:
     """Extract the user's timezone (UTC offset) from the display name."""
     match = timezone_regex.search(display_name)

--- a/buttercup/cogs/helpers.py
+++ b/buttercup/cogs/helpers.py
@@ -32,5 +32,8 @@ def extract_utc_offset(display_name: str) -> int:
 def get_duration_str(start: datetime) -> str:
     """Get the processing duration based on the start time."""
     duration = datetime.now() - start
-    duration_ms = duration.microseconds / 1000
-    return f"{duration_ms:0.0f} ms"
+    if duration.seconds > 5:
+        return f"{duration.seconds} s"
+
+    duration_ms = duration.seconds * 1000 + duration.microseconds // 1000
+    return f"{duration_ms} ms"

--- a/buttercup/cogs/rules.py
+++ b/buttercup/cogs/rules.py
@@ -1,6 +1,8 @@
 from datetime import datetime
+from typing import List, Optional
 
 import asyncpraw
+from asyncpraw.models import Rule
 from asyncprawcore import NotFound, Redirect
 from discord import Embed
 from discord.ext.commands import Cog
@@ -13,6 +15,9 @@ from buttercup.strings import translation
 i18n = translation()
 
 
+PI_KEYWORDS = ["personal info", "identifying info", "censor"]
+
+
 def extract_sub_name(subreddit: str) -> str:
     """Extract the name of the sub without prefix."""
     if subreddit.startswith("/r/"):
@@ -20,6 +25,24 @@ def extract_sub_name(subreddit: str) -> str:
     if subreddit.startswith("r/"):
         return subreddit[2:]
     return subreddit
+
+
+def contains_any(text: Optional[str], keywords: List[str]) -> bool:
+    """Determine if the text contains any of the keywords."""
+    if text is None:
+        return False
+    lower_text = text.casefold()
+    for word in keywords:
+        if word.casefold() in lower_text:
+            return True
+    return False
+
+
+def is_pi_rule(rule: Rule) -> bool:
+    """Determine if the given rule is regarding personal information."""
+    return contains_any(rule.short_name, PI_KEYWORDS) or contains_any(
+        rule.description, PI_KEYWORDS
+    )
 
 
 class Rules(Cog):
@@ -73,6 +96,58 @@ class Rules(Cog):
         delay = datetime.now() - start
         await msg.edit(
             content=i18n["rules"]["embed_message"].format(
+                f"{delay.microseconds // 1000} ms"
+            ),
+            embed=embed,
+        )
+
+    @cog_ext.cog_slash(
+        name="pirules",
+        description="Get the rules of the specified subreddit regarding personal information.",
+        options=[
+            create_option(
+                name="subreddit",
+                description="The subreddit to get the PI rules of.",
+                option_type=3,
+                required=True,
+            )
+        ],
+    )
+    async def _rules(self, ctx: SlashContext, subreddit: str) -> None:
+        """Get the rules of the specified subreddit regarding personal information."""
+        # Send a quick response
+        # We will edit this later with the actual content
+        start = datetime.now()
+        sub_name = extract_sub_name(subreddit)
+        msg = await ctx.send(i18n["pirules"]["getting_rules"].format(sub_name))
+
+        sub = await self.reddit_api.subreddit(sub_name)
+
+        embed = Embed(title=i18n["pirules"]["embed_title"].format(sub_name))
+
+        try:
+            async for rule in sub.rules:
+                if is_pi_rule(rule):
+                    # The value field is not allowed to be a blank string
+                    # So we just repeat the name of the rule if it is not provided
+                    embed.add_field(
+                        name=rule.short_name,
+                        value=rule.description or rule.short_name,
+                        inline=False,
+                    )
+        except Redirect:
+            # Sometimes Reddit redirects to the subreddit search
+            await msg.edit(content=i18n["pirules"]["sub_not_found"].format(sub_name))
+            return
+        except NotFound:
+            # Sometimes it throws a not found exception, e.g. if a character isn't allowed
+            await msg.edit(content=i18n["pirules"]["sub_not_found"].format(sub_name))
+            return
+
+        delay = datetime.now() - start
+        print("4")
+        await msg.edit(
+            content=i18n["pirules"]["embed_message"].format(
                 f"{delay.microseconds // 1000} ms"
             ),
             embed=embed,

--- a/buttercup/cogs/rules.py
+++ b/buttercup/cogs/rules.py
@@ -7,6 +7,7 @@ from asyncprawcore import Forbidden, NotFound, Redirect
 from discord import Embed
 from discord.ext.commands import Cog
 from discord_slash import SlashContext, cog_ext
+from discord_slash.model import SlashMessage
 from discord_slash.utils.manage_commands import create_option
 
 from buttercup.bot import ButtercupBot
@@ -52,11 +53,62 @@ def is_pi_rule(rule: Rule) -> bool:
     )
 
 
+async def send_rules_message(
+    msg: SlashMessage,
+    rules: List[Rule],
+    subreddit: str,
+    start_time: datetime,
+    localization_key: str,
+) -> None:
+    """Send an embed containing the rules to the user."""
+    embed = Embed(title=i18n[localization_key]["embed_title"].format(subreddit))
+
+    if len(rules) == 0:
+        await msg.edit(content=i18n[localization_key]["no_rules"].format(subreddit))
+        return
+
+    for rule in rules:
+        # The value field is not allowed to be a blank string
+        # So we just repeat the name of the rule if it is not provided
+        embed.add_field(
+            name=rule.short_name,
+            value=rule.description or rule.short_name,
+            inline=False,
+        )
+
+    delay = datetime.now() - start_time
+    await msg.edit(
+        content=i18n["rules"]["embed_message"].format(
+            f"{delay.microseconds // 1000} ms"
+        ),
+        embed=embed,
+    )
+
+
 class Rules(Cog):
     def __init__(self, bot: ButtercupBot, reddit_api: asyncpraw.Reddit) -> None:
         """Initialize the Rules cog."""
         self.bot = bot
         self.reddit_api = reddit_api
+
+    async def _get_rule_list(
+        self, msg: SlashMessage, subreddit: str
+    ) -> Optional[List[Rule]]:
+        """Get the list of rules for the given subreddit."""
+        try:
+            sub = await self.reddit_api.subreddit(subreddit)
+            return [rule async for rule in sub.rules]
+        except Redirect:
+            # The subreddit does not exist
+            await msg.edit(content=i18n["rules"]["sub_not_found"].format(subreddit))
+        except NotFound:
+            # A character in the sub name is not allowed
+            await msg.edit(content=i18n["rules"]["sub_not_found"].format(subreddit))
+        except Forbidden:
+            # The subreddit is private
+            await msg.edit(content=i18n["rules"]["sub_private"].format(subreddit))
+
+        return None
 
     @cog_ext.cog_slash(
         name="rules",
@@ -72,51 +124,17 @@ class Rules(Cog):
     )
     async def _rules(self, ctx: SlashContext, subreddit: str) -> None:
         """Get the rules of the specified subreddit."""
-        # Send a quick response
-        # We will edit this later with the actual content
         start = datetime.now()
         sub_name = extract_sub_name(subreddit)
+        # Send a quick response
+        # We will edit this later with the actual content
         msg = await ctx.send(i18n["rules"]["getting_rules"].format(sub_name))
 
-        sub = await self.reddit_api.subreddit(sub_name)
-
-        embed = Embed(title=i18n["rules"]["embed_title"].format(sub_name))
-
-        try:
-            rules = [rule async for rule in sub.rules]
-
-            if len(rules) == 0:
-                await msg.edit(content=i18n["rules"]["no_rules"].format(sub_name))
-                return
-
-            async for rule in sub.rules:
-                # The value field is not allowed to be a blank string
-                # So we just repeat the name of the rule if it is not provided
-                embed.add_field(
-                    name=rule.short_name,
-                    value=rule.description or rule.short_name,
-                    inline=False,
-                )
-        except Redirect:
-            # Sometimes Reddit redirects to the subreddit search
-            await msg.edit(content=i18n["rules"]["sub_not_found"].format(sub_name))
-            return
-        except NotFound:
-            # Sometimes it throws a not found exception, e.g. if a character isn't allowed
-            await msg.edit(content=i18n["rules"]["sub_not_found"].format(sub_name))
-            return
-        except Forbidden:
-            # The subreddit is private
-            await msg.edit(content=i18n["rules"]["sub_private"].format(sub_name))
+        rules = await self._get_rule_list(msg, subreddit)
+        if rules is None:
             return
 
-        delay = datetime.now() - start
-        await msg.edit(
-            content=i18n["rules"]["embed_message"].format(
-                f"{delay.microseconds // 1000} ms"
-            ),
-            embed=embed,
-        )
+        await send_rules_message(msg, rules, subreddit, start, "rules")
 
     @cog_ext.cog_slash(
         name="pirules",
@@ -133,57 +151,18 @@ class Rules(Cog):
     )
     async def _pi_rules(self, ctx: SlashContext, subreddit: str) -> None:
         """Get the rules of the specified subreddit regarding personal information."""
-        # Send a quick response
-        # We will edit this later with the actual content
         start = datetime.now()
         sub_name = extract_sub_name(subreddit)
+        # Send a quick response
+        # We will edit this later with the actual content
         msg = await ctx.send(i18n["pi_rules"]["getting_rules"].format(sub_name))
 
-        sub = await self.reddit_api.subreddit(sub_name)
-
-        embed = Embed(title=i18n["pi_rules"]["embed_title"].format(sub_name))
-
-        try:
-            rules = [rule async for rule in sub.rules]
-
-            if len(rules) == 0:
-                await msg.edit(content=i18n["pi_rules"]["no_rules"].format(sub_name))
-                return
-
-            pi_rules = [rule for rule in rules if is_pi_rule(rule)]
-
-            if len(pi_rules) == 0:
-                await msg.edit(content=i18n["pi_rules"]["no_pi_rules"].format(sub_name))
-                return
-
-            for rule in pi_rules:
-                # The value field is not allowed to be a blank string
-                # So we just repeat the name of the rule if it is not provided
-                embed.add_field(
-                    name=rule.short_name,
-                    value=rule.description or rule.short_name,
-                    inline=False,
-                )
-        except Redirect:
-            # Sometimes Reddit redirects to the subreddit search
-            await msg.edit(content=i18n["pi_rules"]["sub_not_found"].format(sub_name))
+        rules = await self._get_rule_list(msg, subreddit)
+        if rules is None:
             return
-        except NotFound:
-            # Sometimes it throws a not found exception, e.g. if a character isn't allowed
-            await msg.edit(content=i18n["pi_rules"]["sub_not_found"].format(sub_name))
-            return
-        except Forbidden:
-            # The subreddit is private
-            await msg.edit(content=i18n["pi_rules"]["sub_private"].format(sub_name))
-            return
+        rules = [rule for rule in rules if is_pi_rule(rule)]
 
-        delay = datetime.now() - start
-        await msg.edit(
-            content=i18n["pi_rules"]["embed_message"].format(
-                f"{delay.microseconds // 1000} ms"
-            ),
-            embed=embed,
-        )
+        await send_rules_message(msg, rules, subreddit, start, "pi_rules")
 
 
 def setup(bot: ButtercupBot) -> None:

--- a/buttercup/cogs/rules.py
+++ b/buttercup/cogs/rules.py
@@ -11,7 +11,7 @@ from discord_slash.model import SlashMessage
 from discord_slash.utils.manage_commands import create_option
 
 from buttercup.bot import ButtercupBot
-from buttercup.cogs.helpers import get_duration_str
+from buttercup.cogs.helpers import extract_sub_name, get_duration_str
 from buttercup.strings import translation
 
 i18n = translation()
@@ -28,15 +28,6 @@ PI_KEYWORDS = [
     "dox",
     "witch hunt",
 ]
-
-
-def extract_sub_name(subreddit: str) -> str:
-    """Extract the name of the sub without prefix."""
-    if subreddit.startswith("/r/"):
-        return subreddit[3:]
-    if subreddit.startswith("r/"):
-        return subreddit[2:]
-    return subreddit
 
 
 def contains_any(text: Optional[str], keywords: List[str]) -> bool:

--- a/buttercup/cogs/rules.py
+++ b/buttercup/cogs/rules.py
@@ -15,7 +15,16 @@ from buttercup.strings import translation
 i18n = translation()
 
 
-PI_KEYWORDS = ["personal info", "identifying info", "censor"]
+PI_KEYWORDS = [
+    "personal info",
+    "identifying info",
+    "censor",
+    "redact",
+    "blur",
+    "obscure",
+    "privacy",
+    "dox",
+]
 
 
 def extract_sub_name(subreddit: str) -> str:
@@ -109,7 +118,8 @@ class Rules(Cog):
 
     @cog_ext.cog_slash(
         name="pirules",
-        description="Get the rules of the specified subreddit regarding personal information.",
+        description="Get the rules of the specified subreddit "
+        "regarding personal information.",
         options=[
             create_option(
                 name="subreddit",

--- a/buttercup/cogs/rules.py
+++ b/buttercup/cogs/rules.py
@@ -3,7 +3,7 @@ from typing import List, Optional
 
 import asyncpraw
 from asyncpraw.models import Rule
-from asyncprawcore import NotFound, Redirect
+from asyncprawcore import Forbidden, NotFound, Redirect
 from discord import Embed
 from discord.ext.commands import Cog
 from discord_slash import SlashContext, cog_ext
@@ -107,6 +107,10 @@ class Rules(Cog):
             # Sometimes it throws a not found exception, e.g. if a character isn't allowed
             await msg.edit(content=i18n["rules"]["sub_not_found"].format(sub_name))
             return
+        except Forbidden:
+            # The subreddit is private
+            await msg.edit(content=i18n["rules"]["sub_private"].format(sub_name))
+            return
 
         delay = datetime.now() - start
         await msg.edit(
@@ -169,6 +173,10 @@ class Rules(Cog):
         except NotFound:
             # Sometimes it throws a not found exception, e.g. if a character isn't allowed
             await msg.edit(content=i18n["pi_rules"]["sub_not_found"].format(sub_name))
+            return
+        except Forbidden:
+            # The subreddit is private
+            await msg.edit(content=i18n["pi_rules"]["sub_private"].format(sub_name))
             return
 
         delay = datetime.now() - start

--- a/buttercup/cogs/rules.py
+++ b/buttercup/cogs/rules.py
@@ -11,6 +11,7 @@ from discord_slash.model import SlashMessage
 from discord_slash.utils.manage_commands import create_option
 
 from buttercup.bot import ButtercupBot
+from buttercup.cogs.helpers import get_duration_str
 from buttercup.strings import translation
 
 i18n = translation()
@@ -25,6 +26,7 @@ PI_KEYWORDS = [
     "obscure",
     "privacy",
     "dox",
+    "witch hunt",
 ]
 
 
@@ -76,11 +78,8 @@ async def send_rules_message(
             inline=False,
         )
 
-    delay = datetime.now() - start_time
     await msg.edit(
-        content=i18n["rules"]["embed_message"].format(
-            f"{delay.microseconds // 1000} ms"
-        ),
+        content=i18n["rules"]["embed_message"].format(get_duration_str(start_time)),
         embed=embed,
     )
 

--- a/buttercup/cogs/rules.py
+++ b/buttercup/cogs/rules.py
@@ -38,13 +38,11 @@ def extract_sub_name(subreddit: str) -> str:
 
 def contains_any(text: Optional[str], keywords: List[str]) -> bool:
     """Determine if the text contains any of the keywords."""
-    if text is None:
-        return False
-    lower_text = text.casefold()
-    for word in keywords:
-        if word.casefold() in lower_text:
-            return True
-    return False
+    return (
+        False
+        if text is None
+        else any(word.casefold() in text.casefold() for word in keywords)
+    )
 
 
 def is_pi_rule(rule: Rule) -> bool:

--- a/buttercup/strings/en_US.yaml
+++ b/buttercup/strings/en_US.yaml
@@ -45,3 +45,12 @@ rules:
     Here are the rules! ({0})
   embed_title: |
     Rules for r/{0}
+pirules:
+  getting_rules: |
+    Getting the rules regarding personal information for r/{0}...
+  sub_not_found: |
+    I couldn't find a sub named r/{0}. Are you sure you spelled it correctly?
+  embed_message: |
+    I automatically detected some rules regarding personal information! ({0})
+  embed_title: |
+    PI Rules for r/{0}

--- a/buttercup/strings/en_US.yaml
+++ b/buttercup/strings/en_US.yaml
@@ -41,15 +41,24 @@ rules:
     Getting the rules for r/{0}...
   sub_not_found: |
     I couldn't find a sub named r/{0}. Are you sure you spelled it correctly?
+  no_rules: |
+    r/{0} doesn't appear to have any rules!
   embed_message: |
     Here are the rules! ({0})
   embed_title: |
     Rules for r/{0}
-pirules:
+pi_rules:
   getting_rules: |
     Getting the rules regarding personal information for r/{0}...
   sub_not_found: |
     I couldn't find a sub named r/{0}. Are you sure you spelled it correctly?
+  no_rules: |
+    r/{0} doesn't have any PI rules, because it doesn't have any rules at all!
+  no_pi_rules: |
+    I couldn't automatically detect any rules regarding personal information for r/{0}, but I'm not perfect!
+
+    You can use the `/rules` command to verify for yourself.
+    Did I miss anything? Please report it to the moderators!
   embed_message: |
     I automatically detected some rules regarding personal information! ({0})
   embed_title: |

--- a/buttercup/strings/en_US.yaml
+++ b/buttercup/strings/en_US.yaml
@@ -41,6 +41,8 @@ rules:
     Getting the rules for r/{0}...
   sub_not_found: |
     I couldn't find a sub named r/{0}. Are you sure you spelled it correctly?
+  sub_private: |
+    Sorry, but it looks like r/{0} has gone private!
   no_rules: |
     r/{0} doesn't appear to have any rules!
   embed_message: |
@@ -52,6 +54,8 @@ pi_rules:
     Getting the rules regarding personal information for r/{0}...
   sub_not_found: |
     I couldn't find a sub named r/{0}. Are you sure you spelled it correctly?
+  sub_private: |
+    Sorry, but it looks like r/{0} has gone private!
   no_rules: |
     r/{0} doesn't have any PI rules, because it doesn't have any rules at all!
   no_pi_rules: |


### PR DESCRIPTION
Relevant issue: Closes #36.

## Description:

Adds a `/pirules` command to automatically identify rules regarding personal information.
This is accomplished by looking for specific keywords in the rule title and description.

I checked most subs with the command and it appears to be reliably detecting all PI rules.

Additionally, this improves the handling of subs with no rules or which are private, also for the `/rules` command.

## Screenshots:

![Response of the bot to the `/pirules` command, if it has PI rules](https://user-images.githubusercontent.com/13908946/123635604-26688500-d81c-11eb-9b09-65403b46e554.png)

![Response of the bot to the `/pirules` command, if it does not have any PI rules](https://user-images.githubusercontent.com/13908946/123635686-3da77280-d81c-11eb-8a3b-2957ca18b779.png)

## Checklist:

- [x] Code Quality
- [x] Pep-8
- [ ] Tests (if applicable)
- [x] Success Criteria Met
- [x] Inline Documentation
- [ ] Wiki Documentation (if applicable)
