### PR TITLE
Add `/claimed` command

### DIFF
--- a/buttercup/cogs/find.py
+++ b/buttercup/cogs/find.py
@@ -266,7 +266,7 @@ class Find(Cog):
             )
         ],
     )
-    async def _find(self, ctx: SlashContext, username: str) -> None:
+    async def _claimed(self, ctx: SlashContext, username: str) -> None:
         # Send a first message to show that the bot is responsive.
         # We will edit this message later with the actual content.
         msg = await ctx.send(f"Looking for posts claimed by u/{username}...")
@@ -276,7 +276,6 @@ class Find(Cog):
             await msg.edit(content=f"Sorry, I couldn't find user u/{username}.")
             return
         volunteer = volunteer_response.data
-        print(volunteer)
 
         submission_response = self.blossom_api.get(
             "submission/", params={"claimed_by": volunteer["id"], "archived": False}
@@ -296,9 +295,21 @@ class Find(Cog):
 
         embed = self.to_embed(dict(submission=submissions[0]))
 
-        print("Sending message...")
+        if len(submissions) == 1:
+            await msg.edit(
+                content=f"u/{username} claimed the following post:", embed=embed
+            )
+            return
+
+        post_list = "\n".join(
+            [
+                f"- [Post {i + 1}]({post['tor_url']})"
+                for i, post in enumerate(submissions)
+            ]
+        )
         await msg.edit(
-            content=f"Here are the posts claimed by u/{username}:", embed=embed
+            content=f"u/{username} claimed {len(submissions)} posts:\n{post_list}",
+            embed=embed,
         )
 
 

--- a/buttercup/cogs/find.py
+++ b/buttercup/cogs/find.py
@@ -260,11 +260,13 @@ class Find(Cog):
     async def _claimed(self, ctx: SlashContext, username: str) -> None:
         # Send a first message to show that the bot is responsive.
         # We will edit this message later with the actual content.
-        msg = await ctx.send(f"Looking for posts claimed by u/{username}...")
+        msg = await ctx.send(
+            i18n["claimed"]["looking_for_claimed_posts"].format(username)
+        )
 
         volunteer_response = self.blossom_api.get_user(username)
         if volunteer_response.status != BlossomStatus.ok:
-            await msg.edit(content=f"Sorry, I couldn't find user u/{username}.")
+            await msg.edit(content=i18n["claimed"]["user_not_found"].format(username))
             return
         volunteer = volunteer_response.data
 
@@ -275,9 +277,7 @@ class Find(Cog):
             "submission/", params={"claimed_by": volunteer["id"], "archived": False}
         )
         if submission_response.status_code != 200:
-            await msg.edit(
-                content=f"Sorry, I couldn't find the submissions by u/{username}."
-            )
+            await msg.edit(content=i18n["claimed"]["posts_not_found"].format(username))
             return
         # Filter out completed posts
         submissions = [
@@ -287,27 +287,30 @@ class Find(Cog):
         ]
 
         if len(submissions) == 0:
-            await msg.edit(
-                content=f"It looks like u/{username} doesn't have any posts claimed right now!"
-            )
+            await msg.edit(content=i18n["claimed"]["no_claimed_posts"].format(username))
             return
 
         embed = to_embed(dict(submission=submissions[0], author=volunteer))
 
         if len(submissions) == 1:
             await msg.edit(
-                content=f"u/{username} claimed the following post:", embed=embed
+                content=i18n["claimed"]["one_post_message"].format(username),
+                embed=embed,
             )
             return
 
         post_list = "\n".join(
             [
-                f"- [Post {i + 1}]({post['tor_url']})"
+                i18n["claimed"]["post_list_item"].format(
+                    i + 1, post["tor_url"], post["url"]
+                )
                 for i, post in enumerate(submissions)
             ]
         )
         await msg.edit(
-            content=f"u/{username} claimed {len(submissions)} posts:\n{post_list}",
+            content=i18n["claimed"]["multiple_posts_message"].format(
+                username, len(submissions), post_list
+            ),
             embed=embed,
         )
 

--- a/buttercup/strings/en_US.yaml
+++ b/buttercup/strings/en_US.yaml
@@ -23,6 +23,21 @@ find:
   please_check_url: |
     Please check that your link is correct; it should lead to either a post on r/TranscribersOfReddit, a post on a partner sub or to a transcription.
   discord_username_link: "[{0}](https://reddit.com/u/{0})"
+claimed:
+  looking_for_claimed_posts: |
+    Looking for posts claimed by u/{0}...
+  user_not_found: |
+    Sorry, I couldn't find user u/{0}.
+  posts_not_found: |
+    Sorry, I couldn't find the posts by u/{0}.
+  no_claimed_posts: |
+    It looks like u/{0} doesn't have any posts claimed right now!
+  one_post_message: |
+    u/{0} claimed the following post:
+  multiple_posts_message: |
+    u/{0} claimed {1} posts:
+    {2}
+  post_list_item: "- **{0}**: [ToR post]({1}) / [partner post]({2})"
 stats:
   getting_stats: |
     Getting stats for all users...


### PR DESCRIPTION
Relevant issue: Closes #43.

## Description:

Adds a `/claimed` command to view the commands claimed by the given user.

Ideally we merge #34 before this one and then add the user extraction from that PR to the `/claimed` command as well.

## Screenshots:

![Multiple claimed post](https://user-images.githubusercontent.com/13908946/123784542-d6e78f00-d8d7-11eb-9c64-401182d761a8.png)

![One claimed post](https://user-images.githubusercontent.com/13908946/123784990-49586f00-d8d8-11eb-9a92-866e41c1d89a.png)

![No claimed posts](https://user-images.githubusercontent.com/13908946/123784613-e8c93200-d8d7-11eb-8792-4984744b6a53.png)

## Checklist:

- [x] Code Quality
- [x] Pep-8
- [ ] Tests (if applicable)
- [x] Success Criteria Met
- [x] Inline Documentation
- [ ] Wiki Documentation (if applicable)
