### PR TITLE
Add `/progress` command

### DIFF
--- a/buttercup/cogs/helpers.py
+++ b/buttercup/cogs/helpers.py
@@ -46,3 +46,11 @@ def get_duration_str(start: datetime) -> str:
 
     duration_ms = duration.seconds * 1000 + duration.microseconds // 1000
     return f"{duration_ms} ms"
+
+
+def get_progress_bar(count: int, total: int, width: int = 10) -> str:
+    """Get a textual progress bar."""
+    bar_count = round(count / total * width)
+    inner_bar_count = min(bar_count, width)
+    outer_bar_count = bar_count - inner_bar_count
+    return f"[{'#' * inner_bar_count}{' ' * (width - inner_bar_count)}]{'#' * outer_bar_count}"

--- a/buttercup/cogs/helpers.py
+++ b/buttercup/cogs/helpers.py
@@ -52,5 +52,6 @@ def get_progress_bar(count: int, total: int, width: int = 10) -> str:
     """Get a textual progress bar."""
     bar_count = round(count / total * width)
     inner_bar_count = min(bar_count, width)
+    inner_space_count = width - inner_bar_count
     outer_bar_count = bar_count - inner_bar_count
-    return f"[{'#' * inner_bar_count}{' ' * (width - inner_bar_count)}]{'#' * outer_bar_count}"
+    return f"[{'#' * inner_bar_count}{' ' * inner_space_count}]{'#' * outer_bar_count}"

--- a/buttercup/cogs/stats.py
+++ b/buttercup/cogs/stats.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta
+from random import randint
 from typing import Optional
 
 from blossom_wrapper import BlossomAPI, BlossomStatus
@@ -95,6 +96,18 @@ class Stats(Cog):
             return
         progress_count = progress_response.json()["count"]
 
+        motivational_messages = i18n["progress"]["motivational_messages"]
+        message_set = []
+
+        # Determine the motivational messages for the current progress
+        for threshold in reversed(motivational_messages):
+            if progress_count >= threshold:
+                message_set = motivational_messages[threshold]
+                break
+
+        # Select a random message
+        motivational_message = message_set[randint(0, len(message_set) - 1)].format(user=user)
+
         await msg.edit(
             content=i18n["progress"]["embed_message"].format(get_duration_str(start)),
             embed=Embed(
@@ -103,6 +116,7 @@ class Stats(Cog):
                     bar=get_progress_bar(progress_count, 100),
                     count=progress_count,
                     total=100,
+                    message=motivational_message,
                 ),
             ),
         )

--- a/buttercup/cogs/stats.py
+++ b/buttercup/cogs/stats.py
@@ -8,7 +8,7 @@ from discord_slash import SlashContext, cog_ext
 from discord_slash.utils.manage_commands import create_option
 
 from buttercup.bot import ButtercupBot
-from buttercup.cogs.helpers import extract_username, get_duration_str
+from buttercup.cogs.helpers import extract_username, get_duration_str, get_progress_bar
 from buttercup.strings import translation
 
 i18n = translation()
@@ -100,7 +100,9 @@ class Stats(Cog):
             embed=Embed(
                 title=i18n["progress"]["embed_title"].format(user),
                 description=i18n["progress"]["embed_description"].format(
-                    progress_count
+                    bar=get_progress_bar(progress_count, 100),
+                    count=progress_count,
+                    total=100,
                 ),
             ),
         )

--- a/buttercup/strings/en_US.yaml
+++ b/buttercup/strings/en_US.yaml
@@ -55,7 +55,7 @@ progress:
   embed_title: |
     Progress of u/{0}
   embed_description: |
-    {0} transcriptions in the last 24 hours.
+    `{bar}` {count}/{total} transcriptions in the last 24 hours.
 heatmap:
   getting_heatmap: |
     Generating a heatmap for u/{0}...

--- a/buttercup/strings/en_US.yaml
+++ b/buttercup/strings/en_US.yaml
@@ -45,7 +45,7 @@ stats:
     **Days Since Inception**: {:,d}
 progress:
   getting_progress: |
-    Getting progress for u/{0}...
+    Getting progress for u/{user} in the last {hours} hours...
   user_not_found: |
     I couldn't find user u/{0}!
   failed_getting_progress: |
@@ -54,8 +54,10 @@ progress:
     Here is the progress! ({0})
   embed_title: |
     Progress of u/{0}
-  embed_description: |
-    `{bar}` {count}/{total} transcriptions in the last 24 hours.
+  embed_description_other: |
+    {count} transcriptions in the last {hours} hours.
+  embed_description_24: |
+    `{bar}` {count}/{total} transcriptions in the last {hours} hours.
 
     {message}
   motivational_messages:

--- a/buttercup/strings/en_US.yaml
+++ b/buttercup/strings/en_US.yaml
@@ -54,12 +54,14 @@ progress:
     Here is the progress! ({0})
   embed_title: |
     Progress of u/{0}
-  embed_description_other: |
-    {count} transcriptions in the last {hours} hours.
   embed_description_24: |
     `{bar}` {count}/{total} transcriptions in the last {hours} hours.
-
-    {message}
+  embed_description_other: |
+    {count} transcriptions in the last {hours} hours.
+  embed_description_new: |
+    Hey u/{user}!
+    It looks like you haven't started transribing yet. Do you need any help to get started?
+    Feel free to ask any questions here or [send us a mod mail](https://www.reddit.com/message/compose?to=/r/TranscribersOfReddit).
   motivational_messages:
     0:
       - Look who's slacking off.

--- a/buttercup/strings/en_US.yaml
+++ b/buttercup/strings/en_US.yaml
@@ -56,6 +56,8 @@ progress:
     Progress of u/{0}
   embed_description_24: |
     `{bar}` {count}/{total} transcriptions in the last {hours} hours.
+
+    {message}
   embed_description_other: |
     {count} transcriptions in the last {hours} hours.
   embed_description_new: |

--- a/buttercup/strings/en_US.yaml
+++ b/buttercup/strings/en_US.yaml
@@ -43,6 +43,19 @@ stats:
     **Volunteers**: {:,d}
     **Transcriptions**: {:,d}
     **Days Since Inception**: {:,d}
+progress:
+  getting_progress: |
+    Getting progress for u/{0}...
+  user_not_found: |
+    I couldn't find user u/{0}!
+  failed_getting_progress: |
+    I couldn't get the progress of u/{0}!
+  embed_message: |
+    Here is the progress! ({0})
+  embed_title: |
+    Progress of u/{0}
+  embed_description: |
+    {0} transcriptions in the last 24 hours.
 heatmap:
   getting_heatmap: |
     Generating a heatmap for u/{0}...

--- a/buttercup/strings/en_US.yaml
+++ b/buttercup/strings/en_US.yaml
@@ -56,6 +56,69 @@ progress:
     Progress of u/{0}
   embed_description: |
     `{bar}` {count}/{total} transcriptions in the last 24 hours.
+
+    {message}
+  motivational_messages:
+    0:
+      - Look who's slacking off.
+      - Taking a break?
+      - Transcribing a post would be a good start.
+      - At that pace we're gonna be here a long time.
+      - There are people who transcribe and there's u/{user}.
+      - Not sure what you expected. You know exactly how much it is.
+      - Slow and stead wins the race. Too bad this is not a race.
+      - At least there are more posts for the others.
+      - ":sleeping:"
+      - ":yawning_face:"
+    1:
+      - A good start, keep on going!
+      - Don't worry, you'll get there eventually!
+      - It's a long road, but a rewarding one!
+      - '"After executing the `/progress` command, u/{user} claimed another post."'
+      - Oh! Do it again!
+      - More. MORE!
+    25:
+      - Go forth and conquer!
+      - I see, the motivation is there!
+      - One quarter done. Will the rest follow?
+    50:
+      - Halfway there!
+      - The first half is done. Remember to take a break!
+      - I'm a "progress bar is half full" kind of bot.
+      - That's half of it. Wanna push on?
+    75:
+      - We're getting there, keep on going!
+      - It's getting warmer, warmer...
+      - Good human!
+    95:
+      - So close!
+      - I can already *taste* victory!
+      - Only a few more!
+      - I can see the light at the end of the tunnel...
+      - ":pinching_hand:"
+    100:
+      - "Done and dusted! Great job! :partying_face:"
+      - "It's finally done! Congrats! :tada:"
+      - '"Challenge? What challenge?", u/{user} said.'
+      - The party will be at my place!
+      - Pop the champagne, u/{user} did it!
+      - I wish I could be as cool as u/{user}...
+    105:
+      - You're already finished. You can stop now.
+      - It's addicting, isn't it?
+    200:
+      - u/{user}. We'll remember that name for a long time.
+      - I thought I was the only bot here...
+      - You can't split your 200/24 and give half of it to another user. Just thought I should clarify this.
+      - Sometimes I ask myself how many cats u/{user} trained to make transcriptions for them.
+    300:
+      - Uhm. Please leave a few posts for the others...
+    400:
+      - Clearing the queue all by yourself?
+      - I'm not a doctor, but I'm not sure how healthy this is...
+    500:
+      - Well. It finally happened. And of course it's u/{user}.
+      - Is that a 500/24 or is the progress bar just happy to see me?
 heatmap:
   getting_heatmap: |
     Generating a heatmap for u/{0}...


### PR DESCRIPTION
Relevant issue: Closes #23.

## Description:

Adds a `/progress` command to display the 100/24 progress of a user.
This is one of the most often used commands of the old bot.

If 24 hours are specified as time frame (default), the bot will display a progress bar to reach 100/24. Additionally, a random motivational message for the current transcription count will be displayed.

Feel free to add more motivational messages or edit the existing ones, the more variety we have the better!

## Screenshots:

![Progress for no transcriptions](https://user-images.githubusercontent.com/13908946/124351136-e37e2700-dbf8-11eb-9406-0600a2de23de.png)

![Progress for 65 transcriptions](https://user-images.githubusercontent.com/13908946/124351214-538cad00-dbf9-11eb-8295-58cef497d988.png)

![Progress for new user](https://user-images.githubusercontent.com/13908946/124351224-6ef7b800-dbf9-11eb-8359-5ae98761fcd8.png)

## Checklist:

- [x] Code Quality
- [x] Pep-8
- [ ] Tests (if applicable)
- [x] Success Criteria Met
- [x] Inline Documentation
- [ ] Wiki Documentation (if applicable)
