### PR TITLE
Add `/rate` command

### DIFF
--- a/buttercup/cogs/helpers.py
+++ b/buttercup/cogs/helpers.py
@@ -1,12 +1,13 @@
 import re
 from datetime import datetime
-from typing import List, Union
+from typing import List, Optional, Union
 
+import discord
 from blossom_wrapper import BlossomResponse
 from discord import DiscordException
 from requests import Response
 
-username_regex = re.compile(r"^/?u/(?P<username>\S+)")
+username_regex = re.compile(r"^(?:/?u/)?(?P<username>\S+)")
 timezone_regex = re.compile(r"UTC(?P<offset>[+-]\d+)?", re.RegexFlag.I)
 
 
@@ -36,6 +37,28 @@ def extract_username(display_name: str) -> str:
     if match is None:
         raise NoUsernameException()
     return match.group("username")
+
+
+def get_usernames_from_user_list(
+    user_list: Optional[str], author: Optional[discord.User], limit: int = 5
+) -> List[str]:
+    """Get the individual usernames from a list of users.
+
+    :param user_list: The list of users, separated by spaces.
+    :param author: The author of the message, taken as the default user.
+    :param limit: The maximum number of users to handle.
+    """
+    raw_names = (
+        [user.strip() for user in user_list.split(" ")] if user_list is not None else []
+    )
+
+    if len(raw_names) == 0:
+        # No users provided, fall back to the author of the message
+        if author is None:
+            raise NoUsernameException()
+        return [extract_username(author.display_name)]
+
+    return [extract_username(user) for user in raw_names][:5]
 
 
 def extract_sub_name(subreddit: str) -> str:

--- a/buttercup/cogs/helpers.py
+++ b/buttercup/cogs/helpers.py
@@ -58,7 +58,7 @@ def get_usernames_from_user_list(
             raise NoUsernameException()
         return [extract_username(author.display_name)]
 
-    return [extract_username(user) for user in raw_names][:5]
+    return [extract_username(user) for user in raw_names][:limit]
 
 
 def extract_sub_name(subreddit: str) -> str:

--- a/buttercup/cogs/history.py
+++ b/buttercup/cogs/history.py
@@ -177,7 +177,7 @@ class History(Cog):
         options=[
             create_option(
                 name="users",
-                description="The user to display the history graph for."
+                description="The users to display the history graph for (maximum of 5)."
                 "Defaults to the user executing the command.",
                 option_type=3,
                 required=False,
@@ -286,7 +286,7 @@ class History(Cog):
         options=[
             create_option(
                 name="users",
-                description="The users to display the rate graph for."
+                description="The users to display the rate graph for (maximum of 5)."
                 "Defaults to the user executing the command.",
                 option_type=3,
                 required=False,

--- a/buttercup/cogs/history.py
+++ b/buttercup/cogs/history.py
@@ -16,8 +16,8 @@ from buttercup.bot import ButtercupBot
 from buttercup.cogs import ranks
 from buttercup.cogs.helpers import (
     BlossomException,
-    extract_username,
     get_duration_str,
+    get_usernames_from_user_list,
     join_items_with_and,
 )
 from buttercup.strings import translation
@@ -176,44 +176,26 @@ class History(Cog):
         description="Display the history graph.",
         options=[
             create_option(
-                name="user_1",
-                description="The user to display the history graph for.",
-                option_type=3,
-                required=False,
-            ),
-            create_option(
-                name="user_2",
-                description="The second user to add to the graph.",
-                option_type=3,
-                required=False,
-            ),
-            create_option(
-                name="user_3",
-                description="The third user to add to the graph.",
+                name="users",
+                description="The user to display the history graph for."
+                "Defaults to the user executing the command.",
                 option_type=3,
                 required=False,
             ),
         ],
     )
-    async def _history(
-        self,
-        ctx: SlashContext,
-        user_1: Optional[str] = None,
-        user_2: Optional[str] = None,
-        user_3: Optional[str] = None,
-    ) -> None:
+    async def _history(self, ctx: SlashContext, users: Optional[str] = None,) -> None:
         """Get the transcription history of the user."""
         start = datetime.now()
 
-        username_1 = user_1 or extract_username(ctx.author.display_name)
-        users = [user for user in [username_1, user_2, user_3] if user is not None]
+        users = get_usernames_from_user_list(users, ctx.author)
         usernames = join_items_with_and([f"u/{user}" for user in users])
 
         # Give a quick response to let the user know we're working on it
         # We'll later edit this message with the actual content
         if len(users) == 1:
             msg = await ctx.send(
-                i18n["history"]["getting_history_single"].format(user=username_1)
+                i18n["history"]["getting_history_single"].format(user=users[0])
             )
         else:
             msg = await ctx.send(
@@ -236,7 +218,7 @@ class History(Cog):
             label.set_ha("right")
 
         if len(users) == 1:
-            ax.set_title(i18n["history"]["plot_title_single"].format(user=username_1))
+            ax.set_title(i18n["history"]["plot_title_single"].format(user=users[0]))
         else:
             ax.set_title(i18n["history"]["plot_title_multi"])
 
@@ -303,44 +285,26 @@ class History(Cog):
         description="Display the rate graph.",
         options=[
             create_option(
-                name="user_1",
-                description="The user to display the rate graph for.",
-                option_type=3,
-                required=False,
-            ),
-            create_option(
-                name="user_2",
-                description="The second user to add to the graph.",
-                option_type=3,
-                required=False,
-            ),
-            create_option(
-                name="user_3",
-                description="The third user to add to the graph.",
+                name="users",
+                description="The users to display the rate graph for."
+                "Defaults to the user executing the command.",
                 option_type=3,
                 required=False,
             ),
         ],
     )
-    async def _rate(
-        self,
-        ctx: SlashContext,
-        user_1: Optional[str] = None,
-        user_2: Optional[str] = None,
-        user_3: Optional[str] = None,
-    ) -> None:
+    async def _rate(self, ctx: SlashContext, users: Optional[str] = None,) -> None:
         """Get the transcription rate of the user."""
         start = datetime.now()
 
-        username_1 = user_1 or extract_username(ctx.author.display_name)
-        users = [user for user in [username_1, user_2, user_3] if user is not None]
+        users = get_usernames_from_user_list(users, ctx.author)
         usernames = join_items_with_and([f"u/{user}" for user in users])
 
         # Give a quick response to let the user know we're working on it
         # We'll later edit this message with the actual content
         if len(users) == 1:
             msg = await ctx.send(
-                i18n["rate"]["getting_rate_single"].format(user=username_1)
+                i18n["rate"]["getting_rate_single"].format(user=users[0])
             )
         else:
             msg = await ctx.send(
@@ -363,7 +327,7 @@ class History(Cog):
             label.set_ha("right")
 
         if len(users) == 1:
-            ax.set_title(i18n["rate"]["plot_title_single"].format(user=username_1))
+            ax.set_title(i18n["rate"]["plot_title_single"].format(user=users[0]))
         else:
             ax.set_title(i18n["rate"]["plot_title_multi"])
 

--- a/buttercup/strings/en_US.yaml
+++ b/buttercup/strings/en_US.yaml
@@ -187,3 +187,14 @@ history:
     plot_ylabel: Gamma
     response_message:
       Here is the history graph! ({duration})
+rate:
+    getting_rate_single: |
+      Creating the transcription rate graph for u/{user}...
+    getting_rate_multi: |
+      Creating the transcription rate graph for {users} ({count}/{total})...
+    plot_title_single: Transcription Rate of u/{user}
+    plot_title_multi: Transcription Rate of Multiple Users
+    plot_xlabel: Time
+    plot_ylabel: Transcription Rate
+    response_message:
+      Here is the transcription rate graph! ({duration})


### PR DESCRIPTION
Relevant issue: Closes #22

## Description:

Adds a `/rate` command that displays the transcribing rate of up to three users.

The rate data itself is still wrong due to the placeholder transcriptions still left in Blossom.

## Screenshots:

![Rate graph of a single user](https://user-images.githubusercontent.com/13908946/125207832-078fd700-e28f-11eb-84a4-864997c9b7cc.png)

![Rate graph of multiple users](https://user-images.githubusercontent.com/13908946/125207839-11b1d580-e28f-11eb-952e-644d291cdfd1.png)

## Checklist:

- [x] Code Quality
- [x] Pep-8
- [ ] Tests (if applicable)
- [x] Success Criteria Met
- [x] Inline Documentation
- [ ] Wiki Documentation (if applicable)
