### PR TITLE
Make Buttercup image transparent

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
-![Image of Buttercup, from 1998's Powerpuff Girls](https://i.imgur.com/wx8BXyT.png)
-
+<div align="center">
+  <img align="center" src="https://imgur.com/eoe8Xsv.jpg" height="200px" alt="Image of Buttercup, from 1998's Powerpuff Girls">
+</div>
 <h1 align="center">buttercup</h1>
 
 <p align="center">


### PR DESCRIPTION
Relevant issue: N/A

## Description:

This makes the Buttercup image in the Readme transparent and a little bit smaller. This makes it look much better when using the dark theme, IMO.

## Screenshots:

Old:
![The Readme with an opaque Buttercup image. The white background clashes with the dark grey of the dark theme.](https://user-images.githubusercontent.com/13908946/125593971-d4d60b6e-eb69-418d-b811-f6b4ee66fa8f.png)

New:
![The Readme with the transparent Buttercup image](https://user-images.githubusercontent.com/13908946/125593865-f1e63d78-e181-49cc-8944-8f3cb6a7b19f.png)

## Checklist:

- [ ] Code Quality
- [ ] Pep-8
- [ ] Tests (if applicable)
- [ ] Success Criteria Met
- [ ] Inline Documentation
- [ ] Wiki Documentation (if applicable)
