### PR TITLE
Add `/partner` command

### DIFF
--- a/buttercup/cogs/rules.py
+++ b/buttercup/cogs/rules.py
@@ -168,7 +168,7 @@ class Rules(Cog):
         return partners
 
     @cog_ext.cog_slash(
-        name="partners",
+        name="partner",
         description="Get the list of partner subreddits.",
         options=[
             create_option(
@@ -179,39 +179,54 @@ class Rules(Cog):
             )
         ],
     )
-    async def _partners(
+    async def _partner(
         self, ctx: SlashContext, subreddit: Optional[str] = None
     ) -> None:
         """Get the list of all our partner subreddits."""
+        start = datetime.now()
+
         if subreddit is None:
-            msg = await ctx.send("Getting the list of partner subreddits...")
+            msg = await ctx.send(i18n["partner"]["getting_partner_list"])
         else:
-            msg = await ctx.send(f"Checking if r/{subreddit} is partnered with us...")
+            msg = await ctx.send(
+                i18n["partner"]["getting_partner_status"].format(subreddit=subreddit)
+            )
 
         partners = await self._get_partner_list()
 
         if subreddit is None:
             partner_str = join_items_with_and(partners)
             await msg.edit(
-                content="Here is the list of our partners!",
+                content=i18n["partner"]["embed_partner_list_message"].format(
+                    duration=get_duration_str(start)
+                ),
                 embed=Embed(
-                    title="Partner Subreddits",
-                    description=f"We are partnered with {len(partners)} subreddits:\n\n"
-                    + partner_str,
+                    title=i18n["partner"]["embed_partner_list_title"],
+                    description=i18n["partner"][
+                        "embed_partner_list_description"
+                    ].format(count=len(partners), partner_list=partner_str),
                 ),
             )
         else:
-            message = f"I have determined if r/{subreddit} is partnered with us!"
             is_partner = subreddit.casefold() in [
                 partner.casefold() for partner in partners
             ]
+            message = (
+                i18n["partner"]["embed_partner_status_message"].format(
+                    subreddit=subreddit, duration=get_duration_str(start)
+                ),
+            )
 
             if is_partner:
                 await msg.edit(
                     content=message,
                     embed=Embed(
-                        title=f"r/{subreddit}",
-                        description=f"r/{subreddit} is partnered with us!",
+                        title=i18n["partner"]["embed_partner_status_title"].format(
+                            subreddit=subreddit
+                        ),
+                        description=i18n["partner"][
+                            "embed_partner_status_description_yes"
+                        ].format(subreddit=subreddit),
                         color=Color.green(),
                     ),
                 )
@@ -219,8 +234,12 @@ class Rules(Cog):
                 await msg.edit(
                     content=message,
                     embed=Embed(
-                        title=f"r/{subreddit}",
-                        description=f"r/{subreddit} is not partnered with us yet!",
+                        title=i18n["partner"]["embed_partner_status_title"].format(
+                            subreddit=subreddit
+                        ),
+                        description=i18n["partner"][
+                            "embed_partner_status_description_no"
+                        ].format(subreddit=subreddit),
                         color=Color.red(),
                     ),
                 )

--- a/buttercup/strings/en_US.yaml
+++ b/buttercup/strings/en_US.yaml
@@ -187,3 +187,22 @@ history:
     plot_ylabel: Gamma
     response_message:
       Here is the history graph! ({duration})
+partner:
+  getting_partner_list: |
+    Getting the list of our partners...
+  getting_partner_status: |
+    Getting the partner status of r/{subreddit}...
+  embed_partner_list_message: |
+    Here is the list of our partners! ({duration})
+  embed_partner_list_title: Partner Subreddits
+  embed_partner_list_description: |
+    We are currently partnered with {count} subreddits:
+
+    {partner_list}
+  embed_partner_status_message: |
+    Here is the partner status of r/{subreddit}! ({duration})
+  embed_partner_status_title: Partner Status of r/{subreddit}
+  embed_partner_status_description_yes: |
+    We are partnered with r/{subreddit}! :tada:
+  embed_partner_status_description_no: |
+    We are not partnered with r/{subreddit} yet.

--- a/buttercup/strings/en_US.yaml
+++ b/buttercup/strings/en_US.yaml
@@ -192,6 +192,17 @@ partner:
     Getting the list of our partners...
   getting_partner_status: |
     Getting the partner status of r/{subreddit}...
+  sub_not_found: |
+    Sorry, but I couldn't find the subreddit r/{subreddit}. Please check your spelling.
+  private_message: |
+    They are currently set to **private**. :lock:
+  status_yes_message: |
+    We are partnered with r/{subreddit}! :tada:
+  status_no_message: |
+    We are not partnered with r/{subreddit} at this time.
+  sub_description: |
+    __**Description:**__
+    {description}
   embed_partner_list_message: |
     Here is the list of our partners! ({duration})
   embed_partner_list_title: Partner Subreddits
@@ -202,7 +213,5 @@ partner:
   embed_partner_status_message: |
     Here is the partner status of r/{subreddit}! ({duration})
   embed_partner_status_title: Partner Status of r/{subreddit}
-  embed_partner_status_description_yes: |
-    We are partnered with r/{subreddit}! :tada:
-  embed_partner_status_description_no: |
-    We are not partnered with r/{subreddit} yet.
+  embed_partner_status_description: |
+    {status}


### PR DESCRIPTION
Relevant issue: Closes #48

## Description:

Adds the `/partner` command to determine if a sub is already partnered with us or to get the list of all partnered subreddits.

## Screenshots:

![Response when the sub is partnered](https://user-images.githubusercontent.com/13908946/126038616-6237a897-bce9-4ad1-969f-ae142102ff40.png)

![Response when the sub is not partnered](https://user-images.githubusercontent.com/13908946/126038623-d3eacb85-7a99-49db-b627-d0e594ca945e.png)

![Response when the sub is private](https://user-images.githubusercontent.com/13908946/126038654-73488cc0-91fd-42e3-834a-14bad7734686.png)
## Checklist:

- [x] Code Quality
- [x] Pep-8
- [ ] Tests (if applicable)
- [x] Success Criteria Met
- [x] Inline Documentation
- [ ] Wiki Documentation (if applicable)
