### PR TITLE
Add time filtering to `/rate` and `/history` commands

### DIFF
--- a/buttercup/cogs/heatmap.py
+++ b/buttercup/cogs/heatmap.py
@@ -15,7 +15,6 @@ from buttercup.bot import ButtercupBot
 from buttercup.cogs.helpers import (
     extract_username,
     extract_utc_offset,
-    format_api_time,
     get_duration_str,
     parse_time_constraints,
 )
@@ -121,8 +120,8 @@ class Heatmap(Cog):
         msg = await ctx.send(
             i18n["heatmap"]["getting_heatmap"].format(user=user, time_str=time_str)
         )
-        from_str = format_api_time(after_time)
-        until_str = format_api_time(before_time)
+        from_str = after_time.isoformat() if after_time else None
+        until_str = before_time.isoformat() if before_time else None
 
         volunteer_response = self.blossom_api.get_user(user)
         if not volunteer_response.status == BlossomStatus.ok:

--- a/buttercup/cogs/heatmap.py
+++ b/buttercup/cogs/heatmap.py
@@ -15,6 +15,7 @@ from buttercup.bot import ButtercupBot
 from buttercup.cogs.helpers import (
     extract_username,
     extract_utc_offset,
+    format_api_time,
     get_duration_str,
     parse_time_constraints,
 )
@@ -120,8 +121,8 @@ class Heatmap(Cog):
         msg = await ctx.send(
             i18n["heatmap"]["getting_heatmap"].format(user=user, time_str=time_str)
         )
-        from_str = after_time.strftime("%Y-%m-%dT%H:%M:%S") if after_time else None
-        until_str = before_time.strftime("%Y-%m-%dT%H:%M:%S") if before_time else None
+        from_str = format_api_time(after_time)
+        until_str = format_api_time(before_time)
 
         volunteer_response = self.blossom_api.get_user(user)
         if not volunteer_response.status == BlossomStatus.ok:

--- a/buttercup/cogs/helpers.py
+++ b/buttercup/cogs/helpers.py
@@ -266,3 +266,10 @@ def parse_time_constraints(
     time_str = f"from {after_time_str} until {before_time_str}"
 
     return after_time, before_time, time_str
+
+
+def format_api_time(date_time: Optional[datetime]) -> Optional[str]:
+    """Format a date time to be used as an API parameter."""
+    # For some reason Blossom currently returns a normal HTML page
+    # if an ISO string with a timezone is provided
+    return date_time.strftime("%Y-%m-%dT%H:%M:%S") if date_time else None

--- a/buttercup/cogs/helpers.py
+++ b/buttercup/cogs/helpers.py
@@ -243,6 +243,8 @@ def try_parse_time(time_str: str) -> Tuple[datetime, str]:
     # For example "2021-09-03"
     try:
         absolute_time = parser.parse(time_str)
+        # Make sure it has a timezone
+        absolute_time = absolute_time.replace(tzinfo=absolute_time.tzinfo or pytz.utc)
         absolute_time_str = format_absolute_datetime(absolute_time)
         return absolute_time, absolute_time_str
     except ValueError:

--- a/buttercup/cogs/helpers.py
+++ b/buttercup/cogs/helpers.py
@@ -268,10 +268,3 @@ def parse_time_constraints(
     time_str = f"from {after_time_str} until {before_time_str}"
 
     return after_time, before_time, time_str
-
-
-def format_api_time(date_time: Optional[datetime]) -> Optional[str]:
-    """Format a date time to be used as an API parameter."""
-    # For some reason Blossom currently returns a normal HTML page
-    # if an ISO string with a timezone is provided
-    return date_time.strftime("%Y-%m-%dT%H:%M:%S") if date_time else None

--- a/buttercup/cogs/history.py
+++ b/buttercup/cogs/history.py
@@ -17,7 +17,6 @@ from buttercup.bot import ButtercupBot
 from buttercup.cogs import ranks
 from buttercup.cogs.helpers import (
     BlossomException,
-    format_api_time,
     get_duration_str,
     get_usernames_from_user_list,
     join_items_with_and,
@@ -144,8 +143,8 @@ class History(Cog):
         # Placeholder until we get the real value from the response
         next_page = "1"
 
-        from_str = format_api_time(after_time)
-        until_str = format_api_time(before_time)
+        from_str = after_time.isoformat() if after_time else None
+        until_str = before_time.isoformat() if before_time else None
 
         while next_page is not None:
             response = self.blossom_api.get(
@@ -213,7 +212,7 @@ class History(Cog):
                     "submission/",
                     params={
                         "completed_by": user_id,
-                        "until": format_api_time(before_time),
+                        "until": before_time.isoformat(),
                         "page_size": 1,
                     },
                 )

--- a/buttercup/cogs/history.py
+++ b/buttercup/cogs/history.py
@@ -266,12 +266,12 @@ class History(Cog):
         # We'll later edit this message with the actual content
         if len(users) == 1:
             msg = await ctx.send(
-                i18n["history"]["getting_history_single"].format(user=users[0])
+                i18n["history"]["getting_history_single"].format(user=users[0], time_str=time_str)
             )
         else:
             msg = await ctx.send(
                 i18n["history"]["getting_history_multi"].format(
-                    users=usernames, count=0, total=len(users)
+                    users=usernames, time_str=time_str, count=0, total=len(users)
                 )
             )
 
@@ -322,6 +322,8 @@ class History(Cog):
 
         await msg.edit(
             content=i18n["history"]["response_message"].format(
+                usernames=usernames,
+                time_str=time_str,
                 duration=get_duration_str(start)
             ),
             file=discord_file,
@@ -396,12 +398,12 @@ class History(Cog):
         # We'll later edit this message with the actual content
         if len(users) == 1:
             msg = await ctx.send(
-                i18n["rate"]["getting_rate_single"].format(user=users[0])
+                i18n["rate"]["getting_rate_single"].format(user=users[0], time_str=time_str)
             )
         else:
             msg = await ctx.send(
                 i18n["rate"]["getting_rate_multi"].format(
-                    users=usernames, count=0, total=len(users)
+                    users=usernames, time_str=time_str, count=0, total=len(users)
                 )
             )
 
@@ -458,6 +460,8 @@ class History(Cog):
 
         await msg.edit(
             content=i18n["rate"]["response_message"].format(
+                usernames=usernames,
+                time_str=time_str,
                 duration=get_duration_str(start)
             ),
             file=discord_file,

--- a/buttercup/cogs/history.py
+++ b/buttercup/cogs/history.py
@@ -28,7 +28,9 @@ from buttercup.strings import translation
 i18n = translation()
 
 
-def get_data_granularity(user: Dict, after: Optional[datetime], before: Optional[datetime]) -> str:
+def get_data_granularity(
+    user: Dict, after: Optional[datetime], before: Optional[datetime]
+) -> str:
     """Determine granularity of the graph.
 
     It should be as detailed as possible, but only require 1 API call in the best case.
@@ -41,7 +43,6 @@ def get_data_granularity(user: Dict, after: Optional[datetime], before: Optional
     # The time delta that the data is calculated on
     relevant_delta = (before or now) - (after or date_joined)
     relevant_hours = relevant_delta.total_seconds() / 60
-    relevant_days = relevant_hours / 24
     time_factor = relevant_hours / total_hours
 
     total_gamma: int = user["gamma"]
@@ -52,7 +53,7 @@ def get_data_granularity(user: Dict, after: Optional[datetime], before: Optional
         return "none"
     if relevant_hours * 0.3 <= 500 or adjusted_gamma <= 1500:
         # We estimate that the user is only active in one third of the hours
-        # And the user is expected to complete 3 transcriptions within the same hour on average
+        # The user is expected to complete 3 transcriptions within the same hour
         return "hour"
 
     # Don't be less accurate than a day, it loses too much detail
@@ -178,7 +179,10 @@ class History(Cog):
         return user_data
 
     def get_user_history(
-        self, user_data: str, after_time: Optional[datetime], before_time: Optional[datetime]
+        self,
+        user_data: str,
+        after_time: Optional[datetime],
+        before_time: Optional[datetime],
     ) -> Tuple[int, pd.DataFrame]:
         """Get a data frame representing the history of the user.
 
@@ -266,7 +270,9 @@ class History(Cog):
         # We'll later edit this message with the actual content
         if len(users) == 1:
             msg = await ctx.send(
-                i18n["history"]["getting_history_single"].format(user=users[0], time_str=time_str)
+                i18n["history"]["getting_history_single"].format(
+                    user=users[0], time_str=time_str
+                )
             )
         else:
             msg = await ctx.send(
@@ -322,9 +328,7 @@ class History(Cog):
 
         await msg.edit(
             content=i18n["history"]["response_message"].format(
-                usernames=usernames,
-                time_str=time_str,
-                duration=get_duration_str(start)
+                usernames=usernames, time_str=time_str, duration=get_duration_str(start)
             ),
             file=discord_file,
         )
@@ -398,7 +402,9 @@ class History(Cog):
         # We'll later edit this message with the actual content
         if len(users) == 1:
             msg = await ctx.send(
-                i18n["rate"]["getting_rate_single"].format(user=users[0], time_str=time_str)
+                i18n["rate"]["getting_rate_single"].format(
+                    user=users[0], time_str=time_str
+                )
             )
         else:
             msg = await ctx.send(
@@ -460,9 +466,7 @@ class History(Cog):
 
         await msg.edit(
             content=i18n["rate"]["response_message"].format(
-                usernames=usernames,
-                time_str=time_str,
-                duration=get_duration_str(start)
+                usernames=usernames, time_str=time_str, duration=get_duration_str(start)
             ),
             file=discord_file,
         )

--- a/buttercup/strings/en_US.yaml
+++ b/buttercup/strings/en_US.yaml
@@ -192,17 +192,6 @@ pi_rules:
     I automatically detected some rules regarding personal information! ({0})
   embed_title: |
     PI Rules for r/{0}
-history:
-    getting_history_single: |
-      Creating the history graph for u/{user}...
-    getting_history_multi: |
-      Creating the history graph for {users} ({count}/{total})...
-    plot_title_single: History of u/{user}
-    plot_title_multi: History of Multiple Users
-    plot_xlabel: Time
-    plot_ylabel: Gamma
-    response_message:
-      Here is the history graph! ({duration})
 partner:
   getting_partner_list: |
     Getting the list of our partners...
@@ -231,14 +220,25 @@ partner:
   embed_partner_status_title: Partner Status of r/{subreddit}
   embed_partner_status_description: |
     {status}
+history:
+    getting_history_single: |
+      Creating the history graph for u/{user} {time_str}...
+    getting_history_multi: |
+      Creating the history graph for {users} {time_str} ({count}/{total})...
+    plot_title_single: History of u/{user}
+    plot_title_multi: History of Multiple Users
+    plot_xlabel: Time
+    plot_ylabel: Gamma
+    response_message:
+      Here is the history graph for {usernames} {time_str}! ({duration})
 rate:
     getting_rate_single: |
-      Creating the transcription rate graph for u/{user}...
+      Creating the transcription rate graph for u/{user} {time_str}...
     getting_rate_multi: |
-      Creating the transcription rate graph for {users} ({count}/{total})...
+      Creating the transcription rate graph for {users} {time_str} ({count}/{total})...
     plot_title_single: Transcription Rate of u/{user}
     plot_title_multi: Transcription Rate of Multiple Users
     plot_xlabel: Time
     plot_ylabel: Transcription Rate
     response_message:
-      Here is the transcription rate graph! ({duration})
+      Here is the transcription rate graph for {usernames} {time_str}! ({duration})

--- a/test/test_helpers.py
+++ b/test/test_helpers.py
@@ -149,10 +149,22 @@ def test_format_relative_datetime(amount: float, unit_key: str, expected: str) -
 @mark.parametrize(
     "input_str,expected_datetime,expected_str",
     [
-        ("2020-03-04 10:13", datetime(2020, 3, 4, 10, 13), "2020-03-04 10:13"),
-        ("2020-03-04T10:13", datetime(2020, 3, 4, 10, 13), "2020-03-04 10:13"),
-        ("2020-03-04", datetime(2020, 3, 4), "2020-03-04"),
-        ("10:13", datetime(now.year, now.month, now.day, 10, 13), "10:13"),
+        (
+            "2020-03-04 10:13",
+            datetime(2020, 3, 4, 10, 13, tzinfo=pytz.utc),
+            "2020-03-04 10:13",
+        ),
+        (
+            "2020-03-04T10:13",
+            datetime(2020, 3, 4, 10, 13, tzinfo=pytz.utc),
+            "2020-03-04 10:13",
+        ),
+        ("2020-03-04", datetime(2020, 3, 4, tzinfo=pytz.utc), "2020-03-04"),
+        (
+            "10:13",
+            datetime(now.year, now.month, now.day, 10, 13, tzinfo=pytz.utc),
+            "10:13",
+        ),
     ],
 )
 def test_parse_absolute_datetime(
@@ -197,12 +209,18 @@ def test_parse_relative_datetime(
         (None, None, None, None, "from the start until now"),
         ("none", "none", None, None, "from the start until now"),
         ("start", "end", None, None, "from the start until now"),
-        ("2020-01-08", None, datetime(2020, 1, 8), None, "from 2020-01-08 until now"),
+        (
+            "2020-01-08",
+            None,
+            datetime(2020, 1, 8, tzinfo=pytz.utc),
+            None,
+            "from 2020-01-08 until now",
+        ),
         (
             "2020-01-08",
             "2021-09-13T13:20",
-            datetime(2020, 1, 8),
-            datetime(2021, 9, 13, 13, 20),
+            datetime(2020, 1, 8, tzinfo=pytz.utc),
+            datetime(2021, 9, 13, 13, 20, tzinfo=pytz.utc),
             "from 2020-01-08 until 2021-09-13 13:20",
         ),
     ],


### PR DESCRIPTION
Relevant issue Closes #62, closes #58

Merge after GrafeasGroup/blossom#203!

## Description:

This PR adds time filtering to the `/rate` and `/history` commands via the `after` and `before` options.
The time can be provided by an absolute or relative time string, just like for the `/heatmap` command.

Additionally, the automatic time granularity heuristic has been updated to consider the time frame that the data is calculated on.
It now provides a lot finer granularity by default to preserve details in the graphs.

**Note**: Currently a line is drawn until the current date, independent of the filters. This will be fixed in a future PR related to #59.

## Screenshots:

![The history graph with time filtering](https://user-images.githubusercontent.com/13908946/133923096-357fb71e-5f82-413e-b8f6-bcc66b33a26f.png)

## Checklist:

- [x] Code Quality
- [x] Pep-8
- [ ] Tests (if applicable)
- [x] Success Criteria Met
- [x] Inline Documentation
- [ ] Wiki Documentation (if applicable)
