### PR TITLE
Fix /pirules response for no PI rules

### DIFF
--- a/buttercup/strings/en_US.yaml
+++ b/buttercup/strings/en_US.yaml
@@ -170,6 +170,8 @@ rules:
     Sorry, but it looks like r/{0} has gone private!
   no_rules: |
     r/{0} doesn't appear to have any rules!
+  no_filter_rules: |
+    r/{0} doesn't appear to have any rules!
   embed_message: |
     Here are the rules! ({0})
   embed_title: |
@@ -183,7 +185,7 @@ pi_rules:
     Sorry, but it looks like r/{0} has gone private!
   no_rules: |
     r/{0} doesn't have any PI rules, because it doesn't have any rules at all!
-  no_pi_rules: |
+  no_filter_rules: |
     I couldn't automatically detect any rules regarding personal information for r/{0}, but I'm not perfect!
 
     You can use the `/rules` command to verify for yourself.


### PR DESCRIPTION
Relevant issue: Closes #70

## Description:

The `/pirules` command returned the wrong message when no PI rules had been found.
It always responded that the sub didn't have any rules at all, even if it did.
Now it correctly distinguishes between no rules and no PI rules.

## Screenshots:

![The `/pirules` command correctly recognizes that r/cursedcomments has rules, but no PI rules](https://user-images.githubusercontent.com/13908946/135846759-0aa5109f-84a3-4b52-ba99-da5af280c0ff.png)

## Checklist:

- [x] Code Quality
- [x] Pep-8
- [ ] Tests (if applicable)
- [x] Success Criteria Met
- [x] Inline Documentation
- [ ] Wiki Documentation (if applicable)
