### PR TITLE
Fix last active time if user has submissions without completed time

### DIFF
--- a/buttercup/cogs/stats.py
+++ b/buttercup/cogs/stats.py
@@ -126,6 +126,7 @@ class Stats(Cog):
             params={
                 "completed_by": volunteer_data["id"],
                 "ordering": "-complete_time",
+                "complete_time__isnull": False,
                 "page_size": 1,
                 "page": 1,
             },


### PR DESCRIPTION
Relevant issue: Closes #57

⚠️ Merge **after** GrafeasGroup/blossom#204! ⚠️ 

## Description:

When the completed_time attribute is null it appears before the other transcriptions in the ordering.
This resulted in very old times being displayed in some cases.
Now, the submissions without complete time are filtered out, fixing the problem.

## Checklist:

- [x] Code Quality
- [x] Pep-8
- [ ] Tests (if applicable)
- [x] Success Criteria Met
- [x] Inline Documentation
- [ ] Wiki Documentation (if applicable)
