### PR TITLE
Fix KeyError for multi-graph commands

### DIFF
--- a/buttercup/cogs/handlers.py
+++ b/buttercup/cogs/handlers.py
@@ -1,5 +1,5 @@
-import uuid
 import traceback
+import uuid
 
 from discord.errors import DiscordException
 from discord.ext import commands
@@ -28,7 +28,9 @@ class Handlers(commands.Cog):
         self, ctx: commands.Context, error: DiscordException
     ) -> None:
         """Log that a command has errored and provide the user with feedback."""
-        trace = "".join(traceback.format_exception(type(error), error, error.__traceback__))
+        trace = "".join(
+            traceback.format_exception(type(error), error, error.__traceback__)
+        )
 
         if isinstance(error, commands.CheckFailure):
             logger.warning("An unauthorized Command was performed.", ctx)
@@ -53,7 +55,9 @@ class Handlers(commands.Cog):
             )
         else:
             tracker_id = uuid.uuid4()
-            logger.warning(f"[{tracker_id}] {type(error).__name__}: {str(error)}\n{trace}", ctx)
+            logger.warning(
+                f"[{tracker_id}] {type(error).__name__}: {str(error)}\n{trace}", ctx
+            )
             await ctx.send(
                 i18n["handlers"]["unknown_error"].format(tracker_id=tracker_id)
             )

--- a/buttercup/cogs/handlers.py
+++ b/buttercup/cogs/handlers.py
@@ -1,4 +1,5 @@
 import uuid
+import traceback
 
 from discord.errors import DiscordException
 from discord.ext import commands
@@ -27,6 +28,8 @@ class Handlers(commands.Cog):
         self, ctx: commands.Context, error: DiscordException
     ) -> None:
         """Log that a command has errored and provide the user with feedback."""
+        trace = "".join(traceback.format_exception(type(error), error, error.__traceback__))
+
         if isinstance(error, commands.CheckFailure):
             logger.warning("An unauthorized Command was performed.", ctx)
             await ctx.send(i18n["handlers"]["not_authorized"])
@@ -50,7 +53,7 @@ class Handlers(commands.Cog):
             )
         else:
             tracker_id = uuid.uuid4()
-            logger.warning(f"[{tracker_id}] {type(error).__name__}: {str(error)}", ctx)
+            logger.warning(f"[{tracker_id}] {type(error).__name__}: {str(error)}\n{trace}", ctx)
             await ctx.send(
                 i18n["handlers"]["unknown_error"].format(tracker_id=tracker_id)
             )

--- a/buttercup/cogs/history.py
+++ b/buttercup/cogs/history.py
@@ -302,7 +302,10 @@ class History(Cog):
             if len(users) > 1:
                 await msg.edit(
                     content=i18n["history"]["getting_history_multi"].format(
-                        users=usernames, count=index + 1, total=len(users)
+                        users=usernames,
+                        count=index + 1,
+                        total=len(users),
+                        time_str=time_str,
                     )
                 )
 
@@ -434,7 +437,10 @@ class History(Cog):
             if len(users) > 1:
                 await msg.edit(
                     content=i18n["rate"]["getting_rate_multi"].format(
-                        users=usernames, count=index + 1, total=len(users)
+                        users=usernames,
+                        count=index + 1,
+                        total=len(users),
+                        time_str=time_str,
                     )
                 )
 


### PR DESCRIPTION
Relevant issue: Closes #73, closes #35

## Description:

- Log the stack trace when an unknown exception is raised (#35)
- Fix `KeyError` for `/history` and `/rate` commands when using with multiple users

## Checklist:

- [x] Code Quality
- [x] Pep-8
- [x] Tests (if applicable)
- [x] Success Criteria Met
- [x] Inline Documentation
- [ ] Wiki Documentation (if applicable)
