### PR TITLE
Add data labels to `/rate` and `/history` graphs

### DIFF
--- a/buttercup/cogs/history.py
+++ b/buttercup/cogs/history.py
@@ -311,13 +311,22 @@ class History(Cog):
 
             user_gamma, user_data = self.get_user_history(user, after_time, before_time)
             user_gammas.append(user_gamma)
+            color = ranks[index]["color"]
+            last_point = user_data.iloc[-1]
 
             # Plot the graph
             ax.plot(
-                "date",
-                "gamma",
-                data=user_data.reset_index(),
-                color=ranks[index]["color"],
+                "date", "gamma", data=user_data.reset_index(), color=color,
+            )
+            # At a point for the last value
+            ax.scatter(
+                last_point.name, last_point.at["gamma"], color=color, s=4,
+            )
+            # Label the last value
+            ax.annotate(
+                int(last_point.at["gamma"]),
+                xy=(last_point.name, last_point.at["gamma"]),
+                color=color,
             )
 
         # Show ranks when you are close to them already

--- a/buttercup/cogs/history.py
+++ b/buttercup/cogs/history.py
@@ -455,14 +455,26 @@ class History(Cog):
 
             user_data = self.get_user_rate(user, after_time, before_time)
 
-            max_rates.append(user_data["count"].max())
+            max_rate = user_data["count"].max()
+            max_rates.append(max_rate)
+            max_rate_point = user_data[user_data["count"] == max_rate].iloc[0]
+            print(max_rate_point)
+
+            color = ranks[index]["color"]
 
             # Plot the graph
             ax.plot(
-                "date",
-                "count",
-                data=user_data.reset_index(),
-                color=ranks[index]["color"],
+                "date", "count", data=user_data.reset_index(), color=color,
+            )
+            # At a point for the max value
+            ax.scatter(
+                max_rate_point.name, max_rate_point.at["count"], color=color, s=4,
+            )
+            # Label the last value
+            ax.annotate(
+                int(max_rate_point.at["count"]),
+                xy=(max_rate_point.name, max_rate_point.at["count"]),
+                color=color,
             )
 
         # A milestone at every 100 rate


### PR DESCRIPTION
Relevant issue: Closes #78.

## Description:

- Labels the latest point in the `/history` graph
- Labels the maximum point in the `/rate` graph

The positioning of the labels isn't ideal yet and might be improved in future PRs.

## Screenshots:

![Annotation of latest point in history graph](https://user-images.githubusercontent.com/13908946/139668807-46c5ebc3-be9b-4ff6-a5e5-ea391713deca.png)

![Annotation of maximum point in rate graph](https://user-images.githubusercontent.com/13908946/139668877-73d12988-a363-4b08-ad9f-74ebf3c5474e.png)

## Checklist:

- [x] Code Quality
- [x] Pep-8
- [x] Tests (if applicable)
- [x] Success Criteria Met
- [x] Inline Documentation
- [ ] Wiki Documentation (if applicable)
