### PR TITLE
Fix history gamma offset (for real)

### DIFF
--- a/buttercup/cogs/history.py
+++ b/buttercup/cogs/history.py
@@ -122,7 +122,9 @@ def create_file_from_figure(fig: plt.Figure, file_name: str) -> File:
     return File(history_plot, file_name)
 
 
-def get_history_data_from_rate_data(rate_data: pd.DataFrame, offset: int) -> pd.DataFrame:
+def get_history_data_from_rate_data(
+    rate_data: pd.DataFrame, offset: int
+) -> pd.DataFrame:
     """Aggregate the rate data to history data.
 
     :param rate_data: The rate data to calculate the history data from.
@@ -212,7 +214,11 @@ class History(Cog):
                 # We still need to calculate based on the total gamma
                 # It may be the case that not all transcriptions have a date set
                 # Then they are not included in the data nor in the API response
-                return user_data["gamma"] - rate_data.sum() - offset_response.json()["count"]
+                return (
+                    user_data["gamma"]
+                    - rate_data.sum()
+                    - offset_response.json()["count"]
+                )
         else:
             # We can calculate the offset from the given data
             return user_data["gamma"] - rate_data.sum()
@@ -236,10 +242,14 @@ class History(Cog):
 
         # Get all rate data
         time_frame = get_data_granularity(user_data, after_time, before_time)
-        rate_data = self.get_all_rate_data(user_data["id"], time_frame, after_time, before_time)
+        rate_data = self.get_all_rate_data(
+            user_data["id"], time_frame, after_time, before_time
+        )
 
         # Calculate the offset for all data points
-        offset = self.calculate_history_offset(user_data, rate_data, after_time, before_time)
+        offset = self.calculate_history_offset(
+            user_data, rate_data, after_time, before_time
+        )
 
         # Add an up-to-date entry
         rate_data.loc[datetime.now(tz=tzutc())] = [0]
@@ -331,7 +341,9 @@ class History(Cog):
                     )
                 )
 
-            user_gamma, history_data = self.get_user_history(user, after_time, before_time)
+            user_gamma, history_data = self.get_user_history(
+                user, after_time, before_time
+            )
             user_gammas.append(user_gamma)
             color = ranks[index]["color"]
             last_point = history_data.iloc[-1]

--- a/buttercup/cogs/history.py
+++ b/buttercup/cogs/history.py
@@ -122,6 +122,15 @@ def create_file_from_figure(fig: plt.Figure, file_name: str) -> File:
     return File(history_plot, file_name)
 
 
+def get_history_data_from_rate_data(rate_data: pd.DataFrame, offset: int) -> pd.DataFrame:
+    """Aggregate the rate data to history data.
+
+    :param rate_data: The rate data to calculate the history data from.
+    :param offset: The gamma offset at the first point of the graph.
+    """
+    return rate_data.assign(gamma=rate_data.expanding(1).sum() + offset)
+
+
 class History(Cog):
     def __init__(self, bot: ButtercupBot, blossom_api: BlossomAPI) -> None:
         """Initialize the History cog."""
@@ -235,7 +244,7 @@ class History(Cog):
         # Add an up-to-date entry
         rate_data.loc[datetime.now(tz=tzutc())] = [0]
         # Aggregate the gamma score
-        history_data = rate_data.assign(gamma=rate_data.expanding(1).sum() + offset)
+        history_data = get_history_data_from_rate_data(rate_data, offset)
 
         return user_data["gamma"], history_data
 


### PR DESCRIPTION
Relevant issue: #83 

## Description:

Turns out that I didn't push some commits last time (my git aliases weren't configured correctly).
For this reason, only one offset calculation got fixed, the other one (missing data points) was still bugged.

This PR adds those remaining commits and also applies some refactorings to make the code more readable.

## Screenshots:

Before:
![`/history` command before the fix. The final gamma is too low because of missing data.](https://user-images.githubusercontent.com/13908946/142235271-1db6b1d4-514c-4465-92d1-e504fbd99301.png)

After:
![`/history` command after the fix. The graph doesn't start at 0 to account for the missing data.](https://user-images.githubusercontent.com/13908946/142235461-1a50dbb8-c19d-4be5-b09e-7ef6a403a86f.png)

## Checklist:

- [x] Code Quality
- [ ] Pep-8
- [ ] Tests (if applicable)
- [x] Success Criteria Met
- [x] Inline Documentation
- [ ] Wiki Documentation (if applicable)
