### PR TITLE
Add option to use users as goal for `/until` command

### DIFF
--- a/buttercup/cogs/history.py
+++ b/buttercup/cogs/history.py
@@ -1,8 +1,7 @@
 import io
 import math
-import time
 from datetime import datetime, timedelta
-from typing import Dict, List, Optional, Tuple, Union, Any
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import discord
 import matplotlib.pyplot as plt
@@ -26,10 +25,10 @@ from buttercup.cogs.helpers import (
     get_duration_str,
     get_rank,
     get_rgb_from_hex,
+    get_timedelta_str,
     get_usernames_from_user_list,
     join_items_with_and,
     parse_time_constraints,
-    get_timedelta_str,
 )
 from buttercup.strings import translation
 
@@ -590,6 +589,7 @@ class History(Cog):
         target_username: str,
         start: datetime,
     ) -> None:
+        """Determine how long it will take the user to catch up with the target user."""
         # Try to find the target user
         target_response = self.blossom_api.get_user(target_username)
         if target_response.status != BlossomStatus.ok:
@@ -606,10 +606,8 @@ class History(Cog):
         time_frame = timedelta(weeks=1)
 
         try:
-            print("getting progress")
             user_progress = await self._get_user_progress(user, start, time_frame)
             target_progress = await self._get_user_progress(target, start, time_frame)
-            print("got progress")
         except RuntimeError:
             await msg.edit(
                 content=i18n["until"]["failed_getting_prediction"].format(user=user)
@@ -650,6 +648,8 @@ class History(Cog):
                 time_needed=get_timedelta_str(time_needed),
             )
 
+        color = get_rank(target["gamma"])["color"]
+
         await msg.edit(
             content=i18n["until"]["embed_message"].format(
                 duration=get_duration_str(start)
@@ -657,6 +657,7 @@ class History(Cog):
             embed=Embed(
                 title=i18n["until"]["embed_title"].format(user=user["username"]),
                 description=description,
+                color=discord.Colour.from_rgb(*get_rgb_from_hex(color)),
             ),
         )
 

--- a/buttercup/cogs/history.py
+++ b/buttercup/cogs/history.py
@@ -29,6 +29,7 @@ from buttercup.cogs.helpers import (
     get_usernames_from_user_list,
     join_items_with_and,
     parse_time_constraints,
+    get_timedelta_str,
 )
 from buttercup.strings import translation
 
@@ -605,8 +606,10 @@ class History(Cog):
         time_frame = timedelta(weeks=1)
 
         try:
+            print("getting progress")
             user_progress = await self._get_user_progress(user, start, time_frame)
             target_progress = await self._get_user_progress(target, start, time_frame)
+            print("got progress")
         except RuntimeError:
             await msg.edit(
                 content=i18n["until"]["failed_getting_prediction"].format(user=user)
@@ -629,7 +632,6 @@ class History(Cog):
                 (user_progress - target_progress) / time_frame.total_seconds()
             )
             time_needed = timedelta(seconds=seconds_needed)
-            target_time = start + time_needed
 
             intersection_gamma = user["gamma"] + math.ceil(
                 (user_progress / time_frame.total_seconds())
@@ -644,8 +646,8 @@ class History(Cog):
                 target_gamma=target["gamma"],
                 target_progress=target_progress,
                 intersection_gamma=intersection_gamma,
-                time_frame="week",
-                time_needed=f"<t:{time.mktime(target_time.timetuple()):0.0f}:R>",
+                time_frame=get_timedelta_str(time_frame),
+                time_needed=get_timedelta_str(time_needed),
             )
 
         await msg.edit(
@@ -736,9 +738,7 @@ class History(Cog):
         time_frame = timedelta(weeks=1)
 
         try:
-            user_progress = await self._get_user_progress(
-                user, start, time_frame
-            )
+            user_progress = await self._get_user_progress(user, start, time_frame)
         except RuntimeError:
             await msg.edit(
                 content=i18n["until"]["failed_getting_prediction"].format(user=username)
@@ -747,7 +747,10 @@ class History(Cog):
 
         if user_progress == 0:
             description = i18n["until"]["embed_description_zero"].format(
-                time_frame="week", user=username, cur_gamma=user["gamma"], goal=goal_str
+                time_frame=get_timedelta_str(time_frame),
+                user=username,
+                cur_gamma=user["gamma"],
+                goal=goal_str,
             )
         else:
             # Based on the progress in the timeframe, calculate the time needed
@@ -755,7 +758,6 @@ class History(Cog):
             time_needed = timedelta(
                 seconds=gamma_needed * (time_frame.total_seconds() / user_progress)
             )
-            target_time = datetime.now() + time_needed
 
             description = i18n["until"]["embed_description_prediction"].format(
                 time_frame="week",
@@ -763,7 +765,7 @@ class History(Cog):
                 user_gamma=user["gamma"],
                 goal=goal_str,
                 user_progress=user_progress,
-                time_needed=f"<t:{time.mktime(target_time.timetuple()):0.0f}:R>",
+                time_needed=get_timedelta_str(time_needed),
             )
 
         # Determine the color of the target rank

--- a/buttercup/cogs/history.py
+++ b/buttercup/cogs/history.py
@@ -598,10 +598,9 @@ class History(Cog):
         target = target_response.data
 
         if user["gamma"] > target["gamma"]:
-            # Swap user and target
-            temp = user
-            user = target
-            target = temp
+            # Swap user and target, the target has to have more gamma
+            # Otherwise the goal would have already been reached
+            user, target = target, user
 
         time_frame = timedelta(weeks=1)
 

--- a/buttercup/cogs/history.py
+++ b/buttercup/cogs/history.py
@@ -582,7 +582,7 @@ class History(Cog):
             raise RuntimeError("Failed to get progress")
         return progress_response.json()["count"]
 
-    async def _until_user(
+    async def _until_user_catch_up(
         self,
         msg: SlashMessage,
         user: Dict[str, Any],
@@ -705,7 +705,7 @@ class History(Cog):
             try:
                 goal_gamma, goal_str = parse_goal_str(goal)
             except InvalidArgumentException:
-                return await self._until_user(msg, user, goal, start)
+                return await self._until_user_catch_up(msg, user, goal, start)
         else:
             # Take the next rank for the user
             next_rank = get_next_rank(user["gamma"])

--- a/buttercup/cogs/history.py
+++ b/buttercup/cogs/history.py
@@ -667,7 +667,7 @@ class History(Cog):
         options=[
             create_option(
                 name="goal",
-                description="The gamma or flair rank to reach. "
+                description="The gamma, flair rank or user to reach. "
                 "Defaults to the next rank.",
                 option_type=3,
                 required=False,

--- a/buttercup/strings/en_US.yaml
+++ b/buttercup/strings/en_US.yaml
@@ -210,9 +210,9 @@ until:
   embed_title: |
     Prediction for u/{user}
   embed_description_prediction: |
-    **u/{user}** will get from {cur_gamma} to **{goal}** {time_needed} if transcribing at a rate of **{progress}/{time_frame}**.
+    **u/{user}** ({user_gamma}, {user_progress}/{time_frame}) will reach **{goal}** {time_needed}!
   embed_description_zero: |
-    **u/{user}** will never get from {cur_gamma} to **{goal}** at this pace, they haven't transcribed anything in the past {time_frame}!
+    **u/{user}** will never get from {user_gamma} to **{goal}** at this pace, they haven't transcribed anything in the past {time_frame}!
   embed_description_new: |
     Hey u/{user}!
     It looks like you haven't started transribing yet. Do you need any help to get started?
@@ -222,7 +222,7 @@ until:
     **u/{target}** ({target_gamma}, {target_progress}/{time_frame}) {time_needed} at {intersection_gamma} gamma!
   embed_description_user_never: |
     **u/{user}** ({user_gamma}, {user_progress}/{time_frame}) will never catch up with
-    **u/{target}** ({target_gamma}, {target_progress}/{time_frame}) at this rate!
+    **u/{target}** ({target_gamma}, {target_progress}/{time_frame}) at this pace!
 partner:
   getting_partner_list: |
     Getting the list of our partners...

--- a/buttercup/strings/en_US.yaml
+++ b/buttercup/strings/en_US.yaml
@@ -210,7 +210,7 @@ until:
   embed_title: |
     Prediction for u/{user}
   embed_description_prediction: |
-    **u/{user}** ({user_gamma}, {user_progress}/{time_frame}) will reach **{goal}** {time_needed}!
+    **u/{user}** ({user_gamma}, {user_progress}/{time_frame}) will reach **{goal}** in {time_needed}!
   embed_description_zero: |
     **u/{user}** will never get from {user_gamma} to **{goal}** at this pace, they haven't transcribed anything in the past {time_frame}!
   embed_description_new: |
@@ -219,7 +219,7 @@ until:
     Feel free to ask any questions here or [send us a mod mail](https://www.reddit.com/message/compose?to=/r/TranscribersOfReddit).
   embed_description_user_prediction: |
     **u/{user}** ({user_gamma}, {user_progress}/{time_frame}) will catch up with
-    **u/{target}** ({target_gamma}, {target_progress}/{time_frame}) {time_needed} at {intersection_gamma} gamma!
+    **u/{target}** ({target_gamma}, {target_progress}/{time_frame}) in {time_needed} at {intersection_gamma} gamma!
   embed_description_user_never: |
     **u/{user}** ({user_gamma}, {user_progress}/{time_frame}) will never catch up with
     **u/{target}** ({target_gamma}, {target_progress}/{time_frame}) at this pace!

--- a/buttercup/strings/en_US.yaml
+++ b/buttercup/strings/en_US.yaml
@@ -217,6 +217,12 @@ until:
     Hey u/{user}!
     It looks like you haven't started transribing yet. Do you need any help to get started?
     Feel free to ask any questions here or [send us a mod mail](https://www.reddit.com/message/compose?to=/r/TranscribersOfReddit).
+  embed_description_user_prediction: |
+    **u/{user}** ({user_gamma}, {user_progress}/{time_frame}) will catch up with
+    **u/{target}** ({target_gamma}, {target_progress}/{time_frame}) {time_needed} at {intersection_gamma} gamma!
+  embed_description_user_never: |
+    **u/{user}** ({user_gamma}, {user_progress}/{time_frame}) will never catch up with
+    **u/{target}** ({target_gamma}, {target_progress}/{time_frame}) at this rate!
 partner:
   getting_partner_list: |
     Getting the list of our partners...


### PR DESCRIPTION
Relevant issue: Closes #90.

## Description:

This PR adds the option to provide a username as `goal` for the `/until` command.
The bot will then calculate when the user will "catch up" with the goal user, i.e., the intersection points of their gamma considering the rate of the past week.

## Screenshots:

![The `/until` command with a user as goal. It shows how long KomaedaEatsBagels needs until catching up with Tim3303 as well as both their current gamma and transcribing rates.](https://user-images.githubusercontent.com/13908946/142695831-b0f5cd6c-8690-4cf6-871d-cfe9b8a852a0.png)

## Checklist:

- [x] Code Quality
- [x] Pep-8
- [ ] Tests (if applicable)
- [x] Success Criteria Met
- [x] Inline Documentation
- [ ] Wiki Documentation (if applicable)
