### PR TITLE
Allow arbitrary timeframes for /progress command

### DIFF
--- a/buttercup/strings/en_US.yaml
+++ b/buttercup/strings/en_US.yaml
@@ -65,7 +65,7 @@ user_stats:
     **Last Active**: {last_active} ({last_ago})
 progress:
   getting_progress: |
-    Getting progress for u/{user} in the last {hours} hours...
+    Getting progress for u/{user} {time_str}...
   user_not_found: |
     I couldn't find user u/{0}!
   failed_getting_progress: |
@@ -75,11 +75,11 @@ progress:
   embed_title: |
     Progress of u/{0}
   embed_description_24: |
-    `{bar}` {count}/{total} transcriptions in the last {hours} hours.
+    `{bar}` {count}/{total} transcriptions {time_str}.
 
     {message}
   embed_description_other: |
-    {count} transcriptions in the last {hours} hours.
+    {count} transcriptions {time_str}.
   embed_description_new: |
     Hey u/{user}!
     It looks like you haven't started transribing yet. Do you need any help to get started?


### PR DESCRIPTION
Relevant issue: Closes #68.

## Description:

The user can specify an `after` and `before` parameter similar to the `/history` and `/rate` commands.
Both absolute and relative times are supported.

The progress bar is only shown if the time frame is approx. 24 hours long (otherwise the bar wouldn't make much sense).

## Screenshots:

![The `/progress` command, from 48 hours ago until 24 hours ago. Because the time frame is 24 hours long, a progress bar is shown.](https://user-images.githubusercontent.com/13908946/142725821-0d8d9f34-756d-49e3-a6ad-f07b00113ea5.png)

## Checklist:

- [x] Code Quality
- [x] Pep-8
- [ ] Tests (if applicable)
- [x] Success Criteria Met
- [x] Inline Documentation
- [ ] Wiki Documentation (if applicable)
