### PR TITLE
Add `/search` command

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,6 +1,6 @@
 [flake8]
 application-import-names = buttercup
-ignore = ANN101, D100, D101, D105, D106, W503,
+ignore = ANN101, D100, D101, D105, D106, W503, E203,
 import-order-style = pycharm
 max-complexity = 10
 max-line-length = 90

--- a/buttercup/cogs/find.py
+++ b/buttercup/cogs/find.py
@@ -291,7 +291,19 @@ class Find(Cog):
         description = ""
 
         for i, res in enumerate(page_results):
-            description += f"{i + 1}. [Transcription]({res['url']})\n"
+            description += f"{i + 1}. [Transcription]({res['url']})\n```\n"
+            text: str = res["text"]
+            lines = text.splitlines()
+            pos = -1
+            for line in lines:
+                pos = line.casefold().find(query.casefold())
+                if pos >= 0:
+                    # Add the line where the word occurs
+                    description += line + "\n"
+                    # Underline the occurrence
+                    description += " " * pos
+                    description += "-" * len(query) + "\n"
+            description += "```\n"
 
         await msg.edit(
             content=f"Here are your results!",

--- a/buttercup/cogs/find.py
+++ b/buttercup/cogs/find.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from typing import Dict, Optional
 from urllib.parse import urlparse
 
@@ -9,7 +8,6 @@ from discord_slash import SlashContext, cog_ext
 from discord_slash.utils.manage_commands import create_option
 
 from buttercup.bot import ButtercupBot
-from buttercup.cogs.helpers import BlossomException
 from buttercup.strings import translation
 
 i18n = translation()

--- a/buttercup/cogs/find.py
+++ b/buttercup/cogs/find.py
@@ -256,60 +256,6 @@ class Find(Cog):
 
         await msg.edit(content="I found the post!", embed=self.to_embed(data))
 
-    @cog_ext.cog_slash(
-        name="search",
-        description="Searches for transcriptions that contain the given text.",
-        options=[
-            create_option(
-                name="query",
-                description="The text to search for (case-insensitive).",
-                option_type=3,
-                required=True,
-            )
-        ],
-    )
-    async def search(self, ctx: SlashContext, query: str) -> None:
-        """Searches for transcriptions containing the given text."""
-        start = datetime.now()
-
-        # Send a first message to show that the bot is responsive.
-        # We will edit this message later with the actual content.
-        msg = await ctx.send(f"Searching for `{query}`...")
-
-        response = self.blossom_api.get_transcription(
-            text__icontains=query, url__isnull=False, ordering="-create_time"
-        )
-        if response.status != BlossomStatus.ok:
-            raise BlossomException(response)
-        results = response.data
-
-        if len(results) == 0:
-            await msg.edit(content=f"No results for `{query}` found.")
-            return
-
-        page_results = results[:5]
-        description = ""
-
-        for i, res in enumerate(page_results):
-            description += f"{i + 1}. [Transcription]({res['url']})\n```\n"
-            text: str = res["text"]
-            lines = text.splitlines()
-            pos = -1
-            for line in lines:
-                pos = line.casefold().find(query.casefold())
-                if pos >= 0:
-                    # Add the line where the word occurs
-                    description += line + "\n"
-                    # Underline the occurrence
-                    description += " " * pos
-                    description += "-" * len(query) + "\n"
-            description += "```\n"
-
-        await msg.edit(
-            content=f"Here are your results!",
-            embed=Embed(title=f"Results for `{query}`", description=description,),
-        )
-
 
 def setup(bot: ButtercupBot) -> None:
     """Set up the Find cog."""

--- a/buttercup/cogs/search.py
+++ b/buttercup/cogs/search.py
@@ -1,4 +1,5 @@
 import asyncio
+import math
 from datetime import datetime
 import re
 from typing import Any, Dict, TypedDict, Optional, List
@@ -265,7 +266,7 @@ class Search(Cog):
         for i, res in enumerate(page_results):
             description += create_result_description(res, discord_offset + i + 1, query)
 
-        last_discord_page = response_data["count"] // self.discord_page_size
+        total_discord_pages = math.ceil(response_data["count"] / self.discord_page_size)
 
         await msg.edit(
             content=i18n["search"]["embed_message"].format(
@@ -277,7 +278,7 @@ class Search(Cog):
             ).set_footer(
                 text=i18n["search"]["embed_footer"].format(
                     cur_page=discord_page + 1,
-                    total_pages=last_discord_page + 1,
+                    total_pages=total_discord_pages,
                     total_results=response_data["count"],
                 ),
             ),
@@ -289,7 +290,7 @@ class Search(Cog):
         if discord_page > 0:
             emoji_controls.append(first_page_emoji)
             emoji_controls.append(previous_page_emoji)
-        if discord_page < last_discord_page - 1:
+        if discord_page < total_discord_pages - 1:
             emoji_controls.append(next_page_emoji)
             emoji_controls.append(last_page_emoji)
 
@@ -344,7 +345,7 @@ class Search(Cog):
         emoji = reaction.emoji
 
         if response_data := cache_item["response_data"]:
-            last_page = response_data["count"] // self.discord_page_size
+            last_page = math.ceil(response_data["count"] / self.discord_page_size) - 1
         else:
             last_page = 0
 

--- a/buttercup/cogs/search.py
+++ b/buttercup/cogs/search.py
@@ -1,0 +1,89 @@
+from datetime import datetime
+
+from blossom_wrapper import BlossomAPI, BlossomStatus
+from discord import Embed
+from discord.ext.commands import Cog
+from discord_slash import SlashContext, cog_ext
+from discord_slash.utils.manage_commands import create_option
+
+from buttercup.bot import ButtercupBot
+from buttercup.cogs.helpers import BlossomException
+from buttercup.strings import translation
+
+i18n = translation()
+
+
+class Search(Cog):
+    def __init__(self, bot: ButtercupBot, blossom_api: BlossomAPI) -> None:
+        """Initialize the Search cog."""
+        self.bot = bot
+        self.blossom_api = blossom_api
+
+    @cog_ext.cog_slash(
+        name="search",
+        description="Searches for transcriptions that contain the given text.",
+        options=[
+            create_option(
+                name="query",
+                description="The text to search for (case-insensitive).",
+                option_type=3,
+                required=True,
+            )
+        ],
+    )
+    async def search(self, ctx: SlashContext, query: str) -> None:
+        """Searches for transcriptions containing the given text."""
+        start = datetime.now()
+
+        # Send a first message to show that the bot is responsive.
+        # We will edit this message later with the actual content.
+        msg = await ctx.send(f"Searching for `{query}`...")
+
+        response = self.blossom_api.get_transcription(
+            text__icontains=query, url__isnull=False, ordering="-create_time"
+        )
+        if response.status != BlossomStatus.ok:
+            raise BlossomException(response)
+        results = response.data
+
+        if len(results) == 0:
+            await msg.edit(content=f"No results for `{query}` found.")
+            return
+
+        page_results = results[:5]
+        description = ""
+
+        for i, res in enumerate(page_results):
+            description += f"{i + 1}. [Transcription]({res['url']})\n```\n"
+            text: str = res["text"]
+            lines = text.splitlines()
+            pos = -1
+            for line in lines:
+                pos = line.casefold().find(query.casefold())
+                if pos >= 0:
+                    # Add the line where the word occurs
+                    description += line + "\n"
+                    # Underline the occurrence
+                    description += " " * pos
+                    description += "-" * len(query) + "\n"
+            description += "```\n"
+
+        await msg.edit(
+            content=f"Here are your results!",
+            embed=Embed(title=f"Results for `{query}`", description=description,),
+        )
+
+
+def setup(bot: ButtercupBot) -> None:
+    """Set up the Stats cog."""
+    cog_config = bot.config["Blossom"]
+    email = cog_config.get("email")
+    password = cog_config.get("password")
+    api_key = cog_config.get("api_key")
+    blossom_api = BlossomAPI(email=email, password=password, api_key=api_key)
+    bot.add_cog(Search(bot=bot, blossom_api=blossom_api))
+
+
+def teardown(bot: ButtercupBot) -> None:
+    """Unload the Stats cog."""
+    bot.remove_cog("Stats")

--- a/buttercup/cogs/search.py
+++ b/buttercup/cogs/search.py
@@ -14,8 +14,28 @@ from buttercup.strings import translation
 i18n = translation()
 
 
+def format_query_occurrence(line: str, line_num: int, pos: int, query: str) -> str:
+    """Format a single occurrence of the query."""
+    max_context = 20
+    line_num_str = "L" + str(line_num) + ": "
+    before_context = line[:pos]
+    if len(before_context) > max_context:
+        before_context = "..." + before_context[-max_context:]
+    offset = len(line_num_str) + len(before_context)
+    occurrence = line[pos:pos + len(query)]
+    after_context = line[pos + len(query):]
+    if len(after_context) > max_context:
+        after_context = after_context[:max_context] + "..."
+
+    # Show the occurrence with context
+    context = f"{line_num_str}{before_context}{occurrence}{after_context}\n"
+    # Underline the occurrence
+    underline = " " * offset + "-" * len(query) + "\n"
+    return context + underline
+
+
 def create_result_description(result: Dict[str, Any], num: int, query: str) -> str:
-    """Crates a description for the given result."""
+    """Crate a description for the given result."""
     transcription: str = result["text"]
     occurrences = transcription.casefold().count(query.casefold())
     description = f"{num}. [Transcription]({result['url']}) ({occurrences} occurrence(s))\n```\n"
@@ -24,21 +44,8 @@ def create_result_description(result: Dict[str, Any], num: int, query: str) -> s
         pos = line.casefold().find(query.casefold())
         if pos >= 0:
             # Add the line where the word occurs
-            max_context = 20
-            line_num = "L" + str(i + 1) + ": "
-            before_context = line[:pos]
-            if len(before_context) > max_context:
-                before_context = "..." + before_context[-max_context:]
-            offset = len(line_num) + len(before_context)
-            occurrence = line[pos:pos + len(query)]
-            after_context = line[pos + len(query):]
-            if len(after_context) > max_context:
-                after_context = after_context[:max_context] + "..."
+            description += format_query_occurrence(line, i + i, pos, query)
 
-            # Show the occurrence with context
-            description += f"{line_num}{before_context}{occurrence}{after_context}\n"
-            # Underline the occurrence
-            description += " " * offset + "-" * len(query) + "\n"
     description += "```\n"
     return description
 

--- a/buttercup/cogs/search.py
+++ b/buttercup/cogs/search.py
@@ -136,19 +136,27 @@ class Search(Cog):
             raise BlossomException(response)
         results = response.data
 
+        # Internal pagination of results (on Discord)
+        results_per_page = 5
+        total_pages = len(results) // results_per_page
+        cur_page = 0
+
         if len(results) == 0:
             await msg.edit(content=f"No results for `{query}` found.")
             return
 
-        page_results = results[:5]
+        results_offset = cur_page * 5
+        page_results = results[results_offset : results_offset + results_per_page]
         description = ""
 
         for i, res in enumerate(page_results):
-            description += create_result_description(res, i + 1, query)
+            description += create_result_description(res, results_offset + 1, query)
 
         await msg.edit(
             content=f"Here are your results! ({get_duration_str(start)})",
-            embed=Embed(title=f"Results for `{query}`", description=description,),
+            embed=Embed(
+                title=f"Results for `{query}`", description=description,
+            ).set_footer(text=f"Page {cur_page + 1}/{total_pages} ({len(results)} results)"),
         )
 
 

--- a/buttercup/cogs/search.py
+++ b/buttercup/cogs/search.py
@@ -1,8 +1,8 @@
 import asyncio
 import math
-from datetime import datetime
 import re
-from typing import Any, Dict, TypedDict, Optional, List
+from datetime import datetime
+from typing import Any, Dict, List, Optional, TypedDict
 
 import pytz
 from blossom_wrapper import BlossomAPI
@@ -53,7 +53,7 @@ def get_transcription_type(transcription: Dict[str, Any]) -> str:
 
 def get_transcription_source(transcription: Dict[str, Any]) -> str:
     """Try to determine the source (subreddit) of the transcription."""
-    # E.g. https://reddit.com/r/thatHappened/comments/qzhtyb/the_more_you_read_the_less_believable_it_gets/hlmkuau/
+    # https://reddit.com/r/thatHappened/comments/qzhtyb/the_more_you_read_the_less_believable_it_gets/hlmkuau/
     url: str = transcription["url"]
     return "r/" + url.split("/")[4]
 
@@ -142,6 +142,7 @@ class SearchCacheEntry(TypedDict):
 
 class SearchCache:
     def __init__(self, capacity: int) -> None:
+        """Initialize a new cache."""
         self.capacity = capacity
         self.cache = {}
 
@@ -159,7 +160,7 @@ class SearchCache:
         msg_id: str,
         entry: SearchCacheItem,
         time: datetime = datetime.now(tz=pytz.utc),
-    ):
+    ) -> None:
         """Set an entry of the cache.
 
         :param msg_id: The ID of the message where the search results are displayed.
@@ -205,7 +206,7 @@ class Search(Cog):
         cache_item: SearchCacheItem,
         page_mod: int,
     ) -> None:
-        """Executes the search with the given cache."""
+        """Execute the search with the given cache."""
         # Clear previous control emojis
         await msg.clear_reactions()
 
@@ -310,7 +311,7 @@ class Search(Cog):
         ],
     )
     async def search(self, ctx: SlashContext, query: str) -> None:
-        """Searches for transcriptions containing the given text."""
+        """Search for transcriptions containing the given text."""
         start = datetime.now()
 
         # Send a first message to show that the bot is responsive.
@@ -330,7 +331,8 @@ class Search(Cog):
         await self._search_from_cache(msg, start, cache_item, 0)
 
     @commands.Cog.listener()
-    async def on_reaction_add(self, reaction: Reaction, user: User):
+    async def on_reaction_add(self, reaction: Reaction, user: User) -> None:
+        """Process reactions to go through the result pages."""
         start = datetime.now()
         msg: SlashMessage = reaction.message
         cache_item = self.cache.get(msg.id)

--- a/buttercup/cogs/search.py
+++ b/buttercup/cogs/search.py
@@ -37,16 +37,30 @@ def format_query_occurrence(line: str, line_num: int, pos: int, query: str) -> s
 def create_result_description(result: Dict[str, Any], num: int, query: str) -> str:
     """Crate a description for the given result."""
     transcription: str = result["text"]
-    occurrences = transcription.casefold().count(query.casefold())
-    description = f"{num}. [Transcription]({result['url']}) ({occurrences} occurrence(s))\n```\n"
+    total_occurrences = transcription.casefold().count(query.casefold())
+    description = f"{num}. [Transcription]({result['url']}) ({total_occurrences} occurrence(s))\n```\n"
+
+    # The maximum number of occurrences to show
+    max_occurrences = 4
+    cur_count = 0
 
     for i, line in enumerate(transcription.splitlines()):
+        start = 0
         pos = line.casefold().find(query.casefold())
-        if pos >= 0:
+        while pos >= 0 and cur_count < max_occurrences:
             # Add the line where the word occurs
-            description += format_query_occurrence(line, i + i, pos, query)
+            description += format_query_occurrence(line, i + 1, pos, query)
+            # Move to the next occurrence in the line
+            cur_count += 1
+            start = pos + len(query)
+            pos = line.casefold().find(query.casefold(), start)
+
+        if cur_count >= max_occurrences:
+            break
 
     description += "```\n"
+    if cur_count < total_occurrences:
+        description += f"... and {total_occurrences - cur_count} more occurrence(s).\n\n"
     return description
 
 

--- a/buttercup/cogs/search.py
+++ b/buttercup/cogs/search.py
@@ -9,7 +9,7 @@ from discord_slash import SlashContext, cog_ext
 from discord_slash.utils.manage_commands import create_option
 
 from buttercup.bot import ButtercupBot
-from buttercup.cogs.helpers import BlossomException
+from buttercup.cogs.helpers import BlossomException, get_duration_str
 from buttercup.strings import translation
 
 i18n = translation()
@@ -127,7 +127,10 @@ class Search(Cog):
         msg = await ctx.send(f"Searching for `{query}`...")
 
         response = self.blossom_api.get_transcription(
-            text__icontains=query, url__isnull=False, ordering="-create_time"
+            text__icontains=query,
+            url__isnull=False,
+            ordering="-create_time",
+            page_size=100,
         )
         if response.status != BlossomStatus.ok:
             raise BlossomException(response)
@@ -144,7 +147,7 @@ class Search(Cog):
             description += create_result_description(res, i + 1, query)
 
         await msg.edit(
-            content=f"Here are your results!",
+            content=f"Here are your results! ({get_duration_str(start)})",
             embed=Embed(title=f"Results for `{query}`", description=description,),
         )
 

--- a/buttercup/cogs/search.py
+++ b/buttercup/cogs/search.py
@@ -39,6 +39,13 @@ def get_transcription_type(transcription: Dict[str, Any]) -> str:
     return tr_type or tr_format
 
 
+def get_transcription_source(transcription: Dict[str, Any]) -> str:
+    """Try to determine the source (subreddit) of the transcription."""
+    # E.g. https://reddit.com/r/thatHappened/comments/qzhtyb/the_more_you_read_the_less_believable_it_gets/hlmkuau/
+    url: str = transcription["url"]
+    return "r/" + url.split("/")[4]
+
+
 def format_query_occurrence(line: str, line_num: int, pos: int, query: str) -> str:
     """Format a single occurrence of the query."""
     max_context = 20
@@ -64,7 +71,8 @@ def create_result_description(result: Dict[str, Any], num: int, query: str) -> s
     transcription: str = result["text"]
     total_occurrences = transcription.casefold().count(query.casefold())
     tr_type = get_transcription_type(result)
-    description = f"{num}. [{tr_type}]({result['url']}) ({total_occurrences} occurrence(s))\n```\n"
+    tr_source = get_transcription_source(result)
+    description = f"{num}. [{tr_type} on {tr_source}]({result['url']})\n```\n"
 
     # The maximum number of occurrences to show
     max_occurrences = 4

--- a/buttercup/main.py
+++ b/buttercup/main.py
@@ -9,6 +9,7 @@ EXTENSIONS = [
     "welcome",
     "name_validator",
     "find",
+    "search",
     "stats",
     "heatmap",
     "history",

--- a/buttercup/strings/en_US.yaml
+++ b/buttercup/strings/en_US.yaml
@@ -269,3 +269,19 @@ leaderboard:
     Here is the leaderboard for u/{user} {time_str}! ({duration})
   embed_title: |
     Leaderboard for u/{user} ({time_frame})
+search:
+  getting_search: |-
+    Searching for `{query}`...
+  no_results: |-
+    No results found for `{query}`. ({duration_str})
+  description:
+    item: |-
+      {num}. [{tr_type} on {tr_source}]({url})
+    more_occurrences: |-
+      ... and {count} more occurrence(s).
+  embed_message: |-
+    Here are your results for `{query}`! ({duration_str})
+  embed_title: |-
+    Results for `{query}`
+  embed_footer: |-
+    Page {cur_page}/{total_pages} ({total_results} result(s))

--- a/test/test_search.py
+++ b/test/test_search.py
@@ -3,9 +3,9 @@ from datetime import datetime
 from pytest import mark
 
 from buttercup.cogs.search import (
-    get_transcription_type,
-    get_transcription_source,
     SearchCache,
+    get_transcription_source,
+    get_transcription_type,
 )
 
 
@@ -14,7 +14,7 @@ def get_sample_transcription_from_header(header: str) -> str:
     return (
         header
         + """
-    
+
 ---
 
 Bla bla bla
@@ -40,6 +40,7 @@ Footer"""
     ],
 )
 def test_get_transcription_type(transcription: str, expected: str) -> None:
+    """Verify that the transcription type is determined correctly."""
     tr_type = get_transcription_type({"text": transcription})
     assert tr_type == expected
 
@@ -48,22 +49,25 @@ def test_get_transcription_type(transcription: str, expected: str) -> None:
     "url,expected",
     [
         (
-            "https://reddit.com/r/thatHappened/comments/qzhtyb/the_more_you_read_the_less_believable_it_gets/hlmkuau/",
+            "https://reddit.com/r/thatHappened/comments/qzhtyb/the_more_you_read_the_less_believable_it_gets/hlmkuau/",  # noqa: E501
             "r/thatHappened",
         ),
         (
-            "https://reddit.com/r/CasualUK/comments/qzhsco/found_this_bag_of_mints_on_the_floor_which_is/hlmjpoa/",
+            # noqa: E501
+            "https://reddit.com/r/CasualUK/comments/qzhsco/found_this_bag_of_mints_on_the_floor_which_is/hlmjpoa/",  # noqa: E501
             "r/CasualUK",
         ),
     ],
 )
 def test_get_transcription_source(url: str, expected: str) -> None:
+    """Verify that the transcription source is determined correctly."""
     tr_type = get_transcription_source({"url": url})
     assert tr_type == expected
 
 
 class TestSearchCache:
-    def test_search_cache_clean(self):
+    def test_search_cache_clean(self) -> None:
+        """Verify that the cache is cleaned when the capacity is exceeded."""
         cache = SearchCache(1)
         cache.set("abc", {"query": "aaa", "cur_page": 0}, datetime(2021, 1, 3))
         cache.set("def", {"query": "ddd", "cur_page": 0}, datetime(2021, 1, 4))

--- a/test/test_search.py
+++ b/test/test_search.py
@@ -1,0 +1,38 @@
+from pytest import mark
+
+from buttercup.cogs.search import get_transcription_type
+
+
+def get_sample_transcription_from_header(header: str) -> str:
+    """Generate a sample transcription from a header."""
+    return (
+        header
+        + """
+    
+---
+
+Bla bla bla
+
+---
+
+Footer"""
+    )
+
+
+@mark.parametrize(
+    "transcription,expected",
+    [
+        (get_sample_transcription_from_header("*Image Transcription:*"), "Image",),
+        (get_sample_transcription_from_header("*Image Transcription*"), "Image"),
+        (get_sample_transcription_from_header("*Image Transcription: GIF*"), "GIF"),
+        (
+            get_sample_transcription_from_header("*Image Transcription: Tumblr*"),
+            "Tumblr",
+        ),
+        (get_sample_transcription_from_header("*Video Transcription:*"), "Video"),
+        (get_sample_transcription_from_header("aspdpiaosfipasof"), "Post"),
+    ],
+)
+def test_get_transcription_type(transcription: str, expected: str) -> None:
+    tr_type = get_transcription_type({"text": transcription})
+    assert tr_type == expected

--- a/test/test_search.py
+++ b/test/test_search.py
@@ -1,6 +1,6 @@
 from pytest import mark
 
-from buttercup.cogs.search import get_transcription_type
+from buttercup.cogs.search import get_transcription_type, get_transcription_source
 
 
 def get_sample_transcription_from_header(header: str) -> str:
@@ -35,4 +35,22 @@ Footer"""
 )
 def test_get_transcription_type(transcription: str, expected: str) -> None:
     tr_type = get_transcription_type({"text": transcription})
+    assert tr_type == expected
+
+
+@mark.parametrize(
+    "transcription,expected",
+    [
+        (
+            "https://reddit.com/r/thatHappened/comments/qzhtyb/the_more_you_read_the_less_believable_it_gets/hlmkuau/",
+            "r/thatHappened",
+        ),
+        (
+            "https://reddit.com/r/CasualUK/comments/qzhsco/found_this_bag_of_mints_on_the_floor_which_is/hlmjpoa/",
+            "r/CasualUK"
+        )
+    ],
+)
+def test_get_transcription_source(transcription: str, expected: str) -> None:
+    tr_type = get_transcription_source({"text": transcription})
     assert tr_type == expected

--- a/test/test_search.py
+++ b/test/test_search.py
@@ -69,8 +69,28 @@ class TestSearchCache:
     def test_search_cache_clean(self) -> None:
         """Verify that the cache is cleaned when the capacity is exceeded."""
         cache = SearchCache(1)
-        cache.set("abc", {"query": "aaa", "cur_page": 0}, datetime(2021, 1, 3))
-        cache.set("def", {"query": "ddd", "cur_page": 0}, datetime(2021, 1, 4))
+        cache.set(
+            "abc",
+            {
+                "query": "aaa",
+                "cur_page": 0,
+                "response_data": None,
+                "request_page": 0,
+                "discord_user_id": "user",
+            },
+            datetime(2021, 1, 3),
+        )
+        cache.set(
+            "def",
+            {
+                "query": "ddd",
+                "cur_page": 0,
+                "response_data": None,
+                "request_page": 0,
+                "discord_user_id": "user",
+            },
+            datetime(2021, 1, 4),
+        )
 
         assert cache.get("abc") is None
         assert cache.get("def")["query"] == "ddd"

--- a/test/test_search.py
+++ b/test/test_search.py
@@ -47,8 +47,8 @@ def test_get_transcription_type(transcription: str, expected: str) -> None:
         ),
         (
             "https://reddit.com/r/CasualUK/comments/qzhsco/found_this_bag_of_mints_on_the_floor_which_is/hlmjpoa/",
-            "r/CasualUK"
-        )
+            "r/CasualUK",
+        ),
     ],
 )
 def test_get_transcription_source(transcription: str, expected: str) -> None:

--- a/test/test_search.py
+++ b/test/test_search.py
@@ -2,7 +2,11 @@ from datetime import datetime
 
 from pytest import mark
 
-from buttercup.cogs.search import get_transcription_type, get_transcription_source, SearchCache
+from buttercup.cogs.search import (
+    get_transcription_type,
+    get_transcription_source,
+    SearchCache,
+)
 
 
 def get_sample_transcription_from_header(header: str) -> str:

--- a/test/test_search.py
+++ b/test/test_search.py
@@ -1,6 +1,8 @@
+from datetime import datetime
+
 from pytest import mark
 
-from buttercup.cogs.search import get_transcription_type, get_transcription_source
+from buttercup.cogs.search import get_transcription_type, get_transcription_source, SearchCache
 
 
 def get_sample_transcription_from_header(header: str) -> str:
@@ -39,7 +41,7 @@ def test_get_transcription_type(transcription: str, expected: str) -> None:
 
 
 @mark.parametrize(
-    "transcription,expected",
+    "url,expected",
     [
         (
             "https://reddit.com/r/thatHappened/comments/qzhtyb/the_more_you_read_the_less_believable_it_gets/hlmkuau/",
@@ -51,6 +53,16 @@ def test_get_transcription_type(transcription: str, expected: str) -> None:
         ),
     ],
 )
-def test_get_transcription_source(transcription: str, expected: str) -> None:
-    tr_type = get_transcription_source({"text": transcription})
+def test_get_transcription_source(url: str, expected: str) -> None:
+    tr_type = get_transcription_source({"url": url})
     assert tr_type == expected
+
+
+class TestSearchCache:
+    def test_search_cache_clean(self):
+        cache = SearchCache(1)
+        cache.set("abc", {"query": "aaa", "cur_page": 0}, datetime(2021, 1, 3))
+        cache.set("def", {"query": "ddd", "cur_page": 0}, datetime(2021, 1, 4))
+
+        assert cache.get("abc") is None
+        assert cache.get("def")["query"] == "ddd"


### PR DESCRIPTION
Relevant issue: Closes #96.

## Description:

This implements a `/search` command to search for a transcription by a phrase from the transcription text (case-insensitive).
This functionality is available in ToR-Stats via the `!where` command.

In comparison to the old implementation, I made the following improvements:
- Automatic recognition of post type and subreddit (this makes it easier to find the right transcription at a glance).
- Preview of up to four occurrences of the words.
- Line numbers and underline for the occurrences.
- Fixed pagination. Only 5 results are displayed at a time. The user can go through all results by using the provided reaction emojis. On the API side, 25 transcriptions are fetched, so only every 5th page needs to make a new request. (Pagination is currently broken in ToR-Stats)

## Screenshots:

![Response to the `/search` command. Five results are shown on the current page, each highlighting a couple of occurrences of the word `dog`. The bottom shows four reaction emojis to change the current page.](https://user-images.githubusercontent.com/13908946/143067620-c1a6f318-61ef-4c1e-849d-cf0d165a7bc4.png)

## Future Work

- Add option to filter the transcriptions by user. The user executing the command should be set as default.
- Add option to filter by time frame, similar to `/rate` and `/history`.
- Add the author of the transcription to the result output.
- Add the time of the transcription to the result output.

## Checklist:

- [x] Code Quality
- [x] Pep-8
- [x] Tests (if applicable)
- [x] Success Criteria Met
- [x] Inline Documentation
- [ ] Wiki Documentation (if applicable)
