### PR TITLE
Add `/leaderboard` command

### DIFF
--- a/buttercup/cogs/leaderboard.py
+++ b/buttercup/cogs/leaderboard.py
@@ -16,7 +16,7 @@ from buttercup.cogs.helpers import (
     BlossomException,
     get_rgb_from_hex,
     get_rank,
-    parse_time_constraints, InvalidArgumentException,
+    parse_time_constraints, InvalidArgumentException, get_timedelta_str,
 )
 from buttercup.strings import translation
 
@@ -30,6 +30,16 @@ def format_leaderboard_user(user: Dict[str, Any]) -> str:
     gamma = user["gamma"]
 
     return f"{rank}. {username} ({gamma:,})"
+
+
+def format_leaderboard_timeframe(after: Optional[datetime], before: Optional[datetime]) -> str:
+    """Format the time frame that the leaderboard is calculated on."""
+    if not after and not before:
+        return "all time"
+
+    delta = (before or datetime.now(tz=pytz.utc)) - (after or datetime(2017, 4, 1))
+
+    return get_timedelta_str(delta)
 
 
 class Leaderboard(Cog):
@@ -144,6 +154,7 @@ class Leaderboard(Cog):
             description += format_leaderboard_user(below_user) + "\n"
 
         rank = get_rank(user["gamma"])
+        time_frame = format_leaderboard_timeframe(after_time, before_time)
 
         await msg.edit(
             content=i18n["leaderboard"]["embed_message"].format(
@@ -152,7 +163,7 @@ class Leaderboard(Cog):
                 duration=get_duration_str(start)
             ),
             embed=Embed(
-                title=i18n["leaderboard"]["embed_title"].format(user=username),
+                title=i18n["leaderboard"]["embed_title"].format(user=username, time_frame=time_frame),
                 description=description,
                 color=discord.Colour.from_rgb(*get_rgb_from_hex(rank["color"])),
             ),

--- a/buttercup/cogs/leaderboard.py
+++ b/buttercup/cogs/leaderboard.py
@@ -1,11 +1,9 @@
 from datetime import datetime
-from random import choice
 from typing import Optional, Any, Dict
 
 import discord
 import pytz
 from blossom_wrapper import BlossomAPI, BlossomStatus
-from dateutil.parser import parse
 from discord import Embed
 from discord.ext.commands import Cog
 from discord_slash import SlashContext, cog_ext
@@ -14,12 +12,8 @@ from discord_slash.utils.manage_commands import create_option
 from buttercup.bot import ButtercupBot
 from buttercup.cogs.helpers import (
     extract_username,
-    get_discord_time_str,
     get_duration_str,
-    get_progress_bar,
-    get_rank,
-    get_rgb_from_hex,
-    parse_time_constraints, BlossomException,
+    BlossomException, get_rgb_from_hex, get_rank,
 )
 from buttercup.strings import translation
 
@@ -115,6 +109,8 @@ class Leaderboard(Cog):
         for below_user in below_users:
             description += format_leaderboard_user(below_user) + "\n"
 
+        rank = get_rank(user["gamma"])
+
         await msg.edit(
             content=i18n["leaderboard"]["embed_message"].format(
                 duration=get_duration_str(start)
@@ -122,6 +118,7 @@ class Leaderboard(Cog):
             embed=Embed(
                 title=i18n["leaderboard"]["embed_title"].format(user=username),
                 description=description,
+                color=discord.Colour.from_rgb(*get_rgb_from_hex(rank["color"])),
             ),
         )
 

--- a/buttercup/cogs/leaderboard.py
+++ b/buttercup/cogs/leaderboard.py
@@ -16,7 +16,7 @@ from buttercup.cogs.helpers import (
     BlossomException,
     get_rgb_from_hex,
     get_rank,
-    parse_time_constraints,
+    parse_time_constraints, InvalidArgumentException,
 )
 from buttercup.strings import translation
 
@@ -86,7 +86,7 @@ class Leaderboard(Cog):
 
         volunteer_response = self.blossom_api.get_user(username)
         if volunteer_response.status != BlossomStatus.ok:
-            raise BlossomException(volunteer_response)
+            raise InvalidArgumentException("username", username)
         user = volunteer_response.data
         username = user["username"]
 

--- a/buttercup/cogs/leaderboard.py
+++ b/buttercup/cogs/leaderboard.py
@@ -1,22 +1,23 @@
 from datetime import datetime
-from typing import Optional, Any, Dict
+from typing import Any, Dict, Optional
 
-import discord
 import pytz
 from blossom_wrapper import BlossomAPI, BlossomStatus
-from discord import Embed
+from discord import Colour, Embed
 from discord.ext.commands import Cog
 from discord_slash import SlashContext, cog_ext
 from discord_slash.utils.manage_commands import create_option
 
 from buttercup.bot import ButtercupBot
 from buttercup.cogs.helpers import (
+    BlossomException,
+    InvalidArgumentException,
     extract_username,
     get_duration_str,
-    BlossomException,
-    get_rgb_from_hex,
     get_rank,
-    parse_time_constraints, InvalidArgumentException, get_timedelta_str,
+    get_rgb_from_hex,
+    get_timedelta_str,
+    parse_time_constraints,
 )
 from buttercup.strings import translation
 
@@ -32,7 +33,9 @@ def format_leaderboard_user(user: Dict[str, Any]) -> str:
     return f"{rank}. {username} ({gamma:,})"
 
 
-def format_leaderboard_timeframe(after: Optional[datetime], before: Optional[datetime]) -> str:
+def format_leaderboard_timeframe(
+    after: Optional[datetime], before: Optional[datetime]
+) -> str:
     """Format the time frame that the leaderboard is calculated on."""
     if not after and not before:
         return "all time"
@@ -158,14 +161,14 @@ class Leaderboard(Cog):
 
         await msg.edit(
             content=i18n["leaderboard"]["embed_message"].format(
-                user=username,
-                time_str=time_str,
-                duration=get_duration_str(start)
+                user=username, time_str=time_str, duration=get_duration_str(start)
             ),
             embed=Embed(
-                title=i18n["leaderboard"]["embed_title"].format(user=username, time_frame=time_frame),
+                title=i18n["leaderboard"]["embed_title"].format(
+                    user=username, time_frame=time_frame
+                ),
                 description=description,
-                color=discord.Colour.from_rgb(*get_rgb_from_hex(rank["color"])),
+                color=Colour.from_rgb(*get_rgb_from_hex(rank["color"])),
             ),
         )
 

--- a/buttercup/cogs/leaderboard.py
+++ b/buttercup/cogs/leaderboard.py
@@ -1,0 +1,127 @@
+from datetime import datetime
+from random import choice
+from typing import Optional, Any, Dict
+
+import discord
+import pytz
+from blossom_wrapper import BlossomAPI, BlossomStatus
+from dateutil.parser import parse
+from discord import Embed
+from discord.ext.commands import Cog
+from discord_slash import SlashContext, cog_ext
+from discord_slash.utils.manage_commands import create_option
+
+from buttercup.bot import ButtercupBot
+from buttercup.cogs.helpers import (
+    extract_username,
+    get_discord_time_str,
+    get_duration_str,
+    get_progress_bar,
+    get_rank,
+    get_rgb_from_hex,
+    parse_time_constraints, BlossomException,
+)
+from buttercup.strings import translation
+
+i18n = translation()
+
+
+def format_leaderboard_user(user: Dict[str, Any]) -> str:
+    """Format one user in the leaderboard."""
+    rank = user["rank"]
+    username = user["username"]
+    gamma = user["gamma"]
+
+    return f"{rank}. {username} ({gamma})"
+
+
+class Leaderboard(Cog):
+    def __init__(self, bot: ButtercupBot, blossom_api: BlossomAPI) -> None:
+        """Initialize the Leaderboard cog."""
+        self.bot = bot
+        self.blossom_api = blossom_api
+
+    @cog_ext.cog_slash(
+        name="leaderboard",
+        description="Get the current leaderboard.",
+        options=[
+            create_option(
+                name="username",
+                description="The username to get the leaderboard for. "
+                "Defaults to the user executing the command.",
+                option_type=3,
+                required=False,
+            )
+        ],
+    )
+    async def leaderboard(self, ctx: SlashContext, username: Optional[str] = None) -> None:
+        """Get the leaderboard for the given user."""
+        start = datetime.now(tz=pytz.utc)
+
+        username = username or extract_username(ctx.author.display_name)
+        # Send a first message to show that the bot is responsive.
+        # We will edit this message later with the actual content.
+        msg = await ctx.send(i18n["leaderboard"]["getting_leaderboard"].format(user=username))
+
+        volunteer_response = self.blossom_api.get_user(username)
+        if volunteer_response.status != BlossomStatus.ok:
+            raise BlossomException(volunteer_response)
+        user = volunteer_response.data
+        username = user["username"]
+
+        top_count = 5
+        context_count = 5
+
+        # Get the leaderboard data
+        leaderboard_response = self.blossom_api.get(
+            "submission/leaderboard",
+            params={
+                "user_id": user["id"],
+                "top_count": top_count,
+                "below_count": context_count,
+                "above_count": context_count,
+            },
+        )
+        if leaderboard_response.status_code != 200:
+            raise BlossomException(leaderboard_response)
+        leaderboard = leaderboard_response.json()
+
+        description = ""
+
+        for top_user in leaderboard["top"]:
+            description += format_leaderboard_user(top_user) + "\n"
+
+        description += "...\n"
+
+        for above_user in leaderboard["above"]:
+            description += format_leaderboard_user(above_user) + "\n"
+
+        description += "**" + format_leaderboard_user(leaderboard["user"]) + "**\n"
+
+        for below_user in leaderboard["below"]:
+            description += format_leaderboard_user(below_user) + "\n"
+
+        await msg.edit(
+            content=i18n["leaderboard"]["embed_message"].format(
+                duration=get_duration_str(start)
+            ),
+            embed=Embed(
+                title=i18n["leaderboard"]["embed_title"].format(user=username),
+                description=description,
+            ),
+        )
+
+
+def setup(bot: ButtercupBot) -> None:
+    """Set up the Leaderboard cog."""
+    cog_config = bot.config["Blossom"]
+    email = cog_config.get("email")
+    password = cog_config.get("password")
+    api_key = cog_config.get("api_key")
+    blossom_api = BlossomAPI(email=email, password=password, api_key=api_key)
+    bot.add_cog(Leaderboard(bot=bot, blossom_api=blossom_api))
+
+
+def teardown(bot: ButtercupBot) -> None:
+    """Unload the Leaderboard cog."""
+    bot.remove_cog("Leaderboard")

--- a/buttercup/main.py
+++ b/buttercup/main.py
@@ -13,6 +13,7 @@ EXTENSIONS = [
     "history",
     "ping",
     "rules",
+    "leaderboard",
 ]
 
 

--- a/buttercup/strings/en_US.yaml
+++ b/buttercup/strings/en_US.yaml
@@ -269,8 +269,8 @@ rate:
       Here is the transcription rate graph for {usernames} {time_str}! ({duration})
 leaderboard:
   getting_leaderboard: |
-    Getting prediction for u/{user}...
+    Getting leaderboard for u/{user} {time_str}...
   embed_message: |
-    Here is the prediction! ({duration})
+    Here is the leaderboard for u/{user} {time_str}! ({duration})
   embed_title: |
     Leaderboard for u/{user}

--- a/buttercup/strings/en_US.yaml
+++ b/buttercup/strings/en_US.yaml
@@ -267,3 +267,10 @@ rate:
     plot_ylabel: Transcription Rate
     response_message:
       Here is the transcription rate graph for {usernames} {time_str}! ({duration})
+leaderboard:
+  getting_leaderboard: |
+    Getting prediction for u/{user}...
+  embed_message: |
+    Here is the prediction! ({duration})
+  embed_title: |
+    Leaderboard for u/{user}

--- a/buttercup/strings/en_US.yaml
+++ b/buttercup/strings/en_US.yaml
@@ -273,4 +273,4 @@ leaderboard:
   embed_message: |
     Here is the leaderboard for u/{user} {time_str}! ({duration})
   embed_title: |
-    Leaderboard for u/{user}
+    Leaderboard for u/{user} ({time_frame})


### PR DESCRIPTION
Relevant issue: Closes #18.

## Description:

This PR adds an implementation of a `/leaderboard` command, which displays a leader-board of the volunteers, sorted by their gamma.
This will replace the `!leaderboard` command of ToR-Stats.

Improvements compared to the previous version:
- Embed colored in the user's rank.
- Users can define the time-frame that the leader-board is calculated on. E.g., they can display the leader-board of last week only.

## Screenshots:

![The response to the `/leaderboard` command for u/Tim3303. It shows the top 5 users, the 5 users with more gamma than the selected user, the selected user in bold on rank 17, and the 5 users below the selected user.](https://user-images.githubusercontent.com/13908946/143564758-9ad7217d-cac5-47fc-86d6-c7891e113535.png)

![The response to the `/leaderboard` command for u/fatalgift for the past week. It shows the top 12 users with the selected user in bold on rank 7.](https://user-images.githubusercontent.com/13908946/143564963-cbffee21-910a-4c34-8331-8ef425e1492e.png)

## Checklist:

- [x] Code Quality
- [x] Pep-8
- [ ] Tests (if applicable)
- [x] Success Criteria Met
- [x] Inline Documentation
- [ ] Wiki Documentation (if applicable)
