### PR TITLE
Send welcome message when new user joins

### DIFF
--- a/buttercup/cogs/welcome.py
+++ b/buttercup/cogs/welcome.py
@@ -1,7 +1,7 @@
 from typing import Optional
 
 from blossom_wrapper import BlossomAPI
-from discord import Member, Guild, TextChannel
+from discord import Member, TextChannel
 from discord.ext.commands import Cog
 
 from buttercup.bot import ButtercupBot
@@ -19,12 +19,20 @@ class Welcome(Cog):
     @Cog.listener()
     async def on_member_join(self, member: Member) -> None:
         """Welcome new members to the server."""
+        # TODO: Trigger this when the rules have been accepted
+        # This event is triggered when the user joins, but they don't have
+        # access to all channels at this point. A pop-up with the rules are
+        # shown and they have to accept that first.
+        # However, Discord currently doesn't seem to provide an event for that.
+        # This causes many to miss the initial welcome message.
         welcome_channel: Optional[TextChannel] = member.guild.system_channel
 
         if not welcome_channel:
             return
 
-        await welcome_channel.send(content=f"Welcome {member.display_name}!")
+        await welcome_channel.send(
+            content=i18n["welcome"]["new_member"].format(user_id=member.id)
+        )
 
 
 def setup(bot: ButtercupBot) -> None:

--- a/buttercup/cogs/welcome.py
+++ b/buttercup/cogs/welcome.py
@@ -1,0 +1,42 @@
+from typing import Optional
+
+from blossom_wrapper import BlossomAPI
+from discord import Member, Guild, TextChannel
+from discord.ext.commands import Cog
+
+from buttercup.bot import ButtercupBot
+from buttercup.strings import translation
+
+i18n = translation()
+
+
+class Welcome(Cog):
+    def __init__(self, bot: ButtercupBot, blossom_api: BlossomAPI) -> None:
+        """Initialize the Welcome cog."""
+        self.bot = bot
+        self.blossom_api = blossom_api
+
+    @Cog.listener()
+    async def on_member_join(self, member: Member) -> None:
+        """Welcome new members to the server."""
+        welcome_channel: Optional[TextChannel] = member.guild.system_channel
+
+        if not welcome_channel:
+            return
+
+        await welcome_channel.send(content=f"Welcome {member.display_name}!")
+
+
+def setup(bot: ButtercupBot) -> None:
+    """Set up the Welcome cog."""
+    cog_config = bot.config["Blossom"]
+    email = cog_config.get("email")
+    password = cog_config.get("password")
+    api_key = cog_config.get("api_key")
+    blossom_api = BlossomAPI(email=email, password=password, api_key=api_key)
+    bot.add_cog(Welcome(bot=bot, blossom_api=blossom_api))
+
+
+def teardown(bot: ButtercupBot) -> None:
+    """Unload the Welcome cog."""
+    bot.remove_cog("welcome")

--- a/buttercup/main.py
+++ b/buttercup/main.py
@@ -6,6 +6,7 @@ from buttercup.bot import ButtercupBot
 EXTENSIONS = [
     "admin",
     "handlers",
+    "welcome",
     "name_validator",
     "find",
     "stats",

--- a/buttercup/strings/en_US.yaml
+++ b/buttercup/strings/en_US.yaml
@@ -20,6 +20,13 @@ name_validator:
     It must have the format `/u/<reddit_username>`, where you replace `<reddit_username>` with your actual username.
   missing_slash_missing_permissions: |
     Hey <@{user_id}>, you seem to be missing the leading slash in your server nickname, but I don't have sufficient permissions to fix it for you!
+welcome:
+  new_member: |
+    Hello, <@{user_id}>! Welcome to the Transcribers of Reddit chill room! :wave:
+    Please **adjust your server nickname** to match your Reddit username. This makes it easier for us to moderate the server.
+
+    To do this on PC, **type `/nick /u/<reddit_username>`** in the chat.
+    On mobile, tap the **hamburger menu** button on the upper left,  tap the **server name**,  tap "**Edit Server Profile**". Cheers!
 find:
   please_check_url: |
     Please check that your link is correct; it should lead to either a post on r/TranscribersOfReddit, a post on a partner sub or to a transcription.


### PR DESCRIPTION
Relevant issue: Closes #82.

## Description:

The bot will send a welcome message with instructions on how to change the display name whenever a new member joins.

## Screenshots:

![A simple welcome message, pinging the user and instructing them to change their display name.](https://user-images.githubusercontent.com/13908946/143609376-1068589c-7bed-460c-ad93-441f24bdd755.png)

## Checklist:

- [x] Code Quality
- [x] Pep-8
- [ ] Tests (if applicable)
- [x] Success Criteria Met
- [x] Inline Documentation
- [ ] Wiki Documentation (if applicable)
