### PR TITLE
Rework name validation

### DIFF
--- a/buttercup/cogs/name_validator.py
+++ b/buttercup/cogs/name_validator.py
@@ -1,8 +1,3 @@
-import copy
-from typing import Any, Callable
-
-import discord.utils
-from discord.channel import TextChannel
 from discord.ext.commands import Cog
 from discord.member import Member
 
@@ -12,207 +7,26 @@ from buttercup.strings import translation
 i18n = translation()
 
 
-class ObservableDict:
-    def __init__(self) -> None:
-        """Initialize the dictionary and a list of observers."""
-        self.dictionary = dict()
-        self.observers = list()
-
-    async def update(self, key: Any, value: Any) -> Any:
-        """Update the value for the key and notify the observers if its a new value."""
-        old = self.dictionary.get(key)
-        self.dictionary[key] = value
-        if old != value:
-            for observer in self.observers:
-                await observer(key, old, value)
-        return self.get(key)
-
-    def get(self, key: Any) -> Any:
-        """Retrieve a copy of the current saved value for the key."""
-        return copy.deepcopy(self.dictionary.get(key))
-
-    def subscribe(self, observer: Callable) -> None:
-        """
-        Subscribe the observer to changes made to the dictionary.
-
-        An observer should be a callable with the following signature:
-        callable(key: Any, old: Any, new: Any),
-        where key is the key updated, old is the value before and new the value
-        after updating.
-        """
-        self.observers.append(observer)
-
-
-class Record:
-    def __init__(self, nickname: str = None, restricted: bool = True) -> None:
-        """
-        Initialize the member record.
-
-        The record contains the following fields:
-        - nickname: The nickname of the member
-        - restricted: Whether the member has restricted access to Discord
-        - compliant: Whether the member complies with all set constraints
-        - new_member: Whether the member is new
-        - correct_nickname: Whether the member's nickname is correct
-        """
-        self.nickname = nickname
-        self.restricted = restricted
-
-    @property
-    def compliant(self) -> bool:
-        """Whether the member complies with all set constraints."""
-        return self.correct_nickname
-
-    @property
-    def new_member(self) -> bool:
-        """Whether the member is new."""
-        return self.nickname is None
-
-    @property
-    def correct_nickname(self) -> bool:
-        """
-        Whether a nickname is correct.
-
-        This check is currently only based on whether the nickname starts with
-        "/u/", but can be extended.
-        """
-        return self.nickname is not None and self.nickname.startswith("/u/")
-
-
 class NameValidator(Cog):
-    def __init__(
-        self,
-        bot: ButtercupBot,
-        restrict_role: str,
-        accepted_role: str,
-        restrict_channel: str,
-        welcome_channel: str,
-    ) -> None:
+    def __init__(self, bot: ButtercupBot, valid_role_id: str,) -> None:
         """Initialize the member's records and retrieve the roles and channels."""
         self.bot = bot
-        self.restrict_name = restrict_role
-        self.accepted_name = accepted_role
-        self.restrict_channel_name = restrict_channel
-        self.welcome_channel_name = welcome_channel
-        self.members = ObservableDict()
-        self.members.subscribe(self._handle_update)
-        self.restrict_role = None
-        self.accepted_role = None
-        self.restrict_channel = None
-        self.welcome_channel = None
-
-    async def _initialize_state_variables(self) -> None:
-        self.restrict_role = self.restrict_role or discord.utils.get(
-            self.bot.guild.roles, name=self.restrict_name
-        )
-        self.accepted_role = self.accepted_role or discord.utils.get(
-            self.bot.guild.roles, name=self.accepted_name
-        )
-        self.restrict_channel = self.restrict_channel or discord.utils.get(
-            self.bot.guild.text_channels, name=self.restrict_channel_name
-        )
-        self.welcome_channel = self.welcome_channel or discord.utils.get(
-            self.bot.guild.text_channels, name=self.welcome_channel_name
-        )
-
-    @Cog.listener()
-    async def on_member_join(self, member: Member) -> None:
-        """Create a member record when they join the server."""
-        await self._initialize_state_variables()
-        await self._create_record(member)
+        self.valid_role_id = valid_role_id
 
     @Cog.listener()
     async def on_member_update(self, before: Member, after: Member) -> None:
-        """Update the member record whenever their Discord profile changes."""
-        await self._initialize_state_variables()
-        record = await self._get_record(after)
-        record.nickname = after.nick
-        record.restricted = self.restrict_role in after.roles
-        await self.members.update(after, record)
+        """Check whether the new nickname corresponds to the guidelines."""
+        before_name = before.display_name
+        after_name = after.display_name
 
-    async def _handle_update(self, member: Member, old: Record, new: Record) -> None:
-        """
-        Handle the update of the member record.
-
-        This method checks what actions have to be taken according to the update that
-        has occurred. These actions include:
-        - Restricting a non-compliant member
-        - Unrestricting a compliant member
-        - Notifying the member of a nickname update, sending a message depending on
-          the correctness of its format
-        """
-        if member == self.bot.user:
-            return
-
-        channel = self.welcome_channel if new.compliant else self.restrict_channel
-        first_time_member = len(set(member.roles).difference({self.restrict_role})) == 1
-        if old is None and new.new_member:
-            await member.add_roles(self.restrict_role)
-            await self._send_message(channel, "new_member", member)
-            return
-
-        if new.restricted and new.compliant:
-            # Remove restriction
-            await member.remove_roles(self.restrict_role)
-            if first_time_member:
-                # They are unrestricted first time, welcome in channel.
-                await self._send_message(channel, "new_lifted", member)
-                await member.add_roles(self.accepted_role)
-                return
-        if not new.restricted and not new.compliant:
-            # Add restriction
-            await member.add_roles(self.restrict_role)
-            await self._send_message(channel, "wrong_nick", member)
-            return
-
-        if new.nickname and old is not None and old.nickname != new.nickname:
-            # The nickname has changed from what we knew before.
-            if new.correct_nickname:
-                # Send confirmation that new nickname is correct.
-                await self._send_message(channel, "correct_nick", member)
-            elif new.nickname.startswith("u/"):
-                # Send message explaining the common wrong prefix.
-                await self._send_message(channel, "wrong_prefix", member)
-            else:
-                # Repeat the wrong nickname instructions.
-                await self._send_message(channel, "wrong_nick", member)
-
-    async def _get_record(self, member: Member) -> Record:
-        """Retrieve the record of the member, creating one if not yet available."""
-        if member not in self.members.dictionary:
-            await self._create_record(member)
-        return self.members.get(member)
-
-    async def _create_record(self, member: Member) -> Record:
-        """Create a record for the specified member."""
-        # Assume the member has accepted the CoC if they do not have the
-        # restriction role or the member has another role than the
-        # restriction role and "@everyone"
-        restricted_check = self.restrict_role in member.roles
-        return await self.members.update(
-            member, Record(nickname=member.nick, restricted=restricted_check),
-        )
-
-    @staticmethod
-    async def _send_message(
-        channel: TextChannel, message_name: str, member: Member
-    ) -> None:
-        """Send the specified message, formatted through the member, in the channel."""
-        await channel.send(i18n["name_validator"][message_name].format(member.id))
+        print(f"Display name changed from {before_name} to {after_name}")
 
 
 def setup(bot: ButtercupBot) -> None:
     """Set up the NameValidator cog."""
     cog_config = bot.config["NameValidator"]
-    restrict_name = cog_config.get("restrict_role", "New User")
-    accepted_name = cog_config.get("accepted_role", "Visitor (0)")
-    restrict_channel = cog_config.get("restrict_channel", "new-user")
-    welcome_channel = cog_config.get("welcome_channel", "off-topic")
-    bot.add_cog(
-        NameValidator(
-            bot, restrict_name, accepted_name, restrict_channel, welcome_channel
-        )
-    )
+    valid_role_id = cog_config.get("valid_role_id")
+    bot.add_cog(NameValidator(bot, valid_role_id))
 
 
 def teardown(bot: ButtercupBot) -> None:

--- a/buttercup/cogs/name_validator.py
+++ b/buttercup/cogs/name_validator.py
@@ -1,7 +1,7 @@
 import re
 from typing import Optional
 
-from discord import TextChannel
+from discord import Forbidden, TextChannel
 from discord.ext.commands import Cog
 from discord.member import Member
 
@@ -55,10 +55,18 @@ class NameValidator(Cog):
 
         if leading_slash is None:
             # The user forgot the forward slash, fix it for them
-            await after.edit(
-                reason="Add leading slash to server nickname",
-                nick=f"/u/{username}{rest}".strip(),
-            )
+            try:
+                await after.edit(
+                    reason="Add leading slash to server nickname",
+                    nick=f"/u/{username}{rest}".strip(),
+                )
+            except Forbidden:
+                # The user is a mod, can't fix the nickname
+                await welcome_channel.send(
+                    content=i18n["name_validator"][
+                        "missing_slash_missing_permissions"
+                    ].format(user_id=after.id, username=username)
+                )
             # The edit will trigger another event.
             # To avoid duplicate messages we don't do anything here
             return

--- a/buttercup/strings/en_US.yaml
+++ b/buttercup/strings/en_US.yaml
@@ -12,26 +12,12 @@ handlers:
   unknown_error: |
     [{tracker_id}] Something went wrong, please contact a moderator with the provided ID.
 name_validator:
-  new_member: |
-    Hello, <@{0}>! Welcome to the Transcribers of Reddit chill room! Thanks for helping make somebody's day better!
+  valid_name: |
+    Hey <@{user_id}>, you are now successfully registered as **u/{username}**. Thank you!
+  invalid_name: |
+    Hey <@{user_id}>, it appears that your new server nickname is **not compliant** with our guidelines.
 
-    You might have noticed that you can only view this Text Channel. We use this channel to make sure your username is equal to your Reddit username. If you have completed this task, you are given full access to the Discord.
-
-    To use your Reddit name in Discord you can simply type `/nick /u/REDDIT_USERNAME`, replacing "REDDIT_USERNAME" with your actual Reddit username.
-
-    If you have any questions or remarks, feel free to send a message in this channel and one of our moderators will be with you shortly! Cheers!
-  correct_nick: |
-    Hey <@{0}>, thank you for changing your nickname to the specified format!
-  wrong_nick: |
-    Hey <@{0}>, it appears that you have changed your nickname to something that is not compliant with our guidelines.
-
-    Make sure to use your Reddit name in Discord by typing `/nick /u/REDDIT_USERNAME`, replacing "REDDIT_USERNAME" with your actual Reddit username.
-
-    If you have any questions or remarks, feel free to send a message in this channel and one of our moderators will be with you shortly! Cheers!
-  wrong_prefix: |
-    Hey <@{0}>, it appears that you have attempted to change your nickname, but forgot the initial `/` in your nickname. Make sure that your nickname starts with `/u/` and not `u/`!
-  new_lifted: |
-    Welcome <@{0}> to the Transcribers of Reddit Discord! Since you have changed your nickname to the correct format, you now have unrestricted access to our Discord. Thanks for your time and enjoy your time in here!
+    It has to have the format `/u/<reddit_username>`, where you replace `<reddit_username>` with your actual username.
 find:
   please_check_url: |
     Please check that your link is correct; it should lead to either a post on r/TranscribersOfReddit, a post on a partner sub or to a transcription.

--- a/buttercup/strings/en_US.yaml
+++ b/buttercup/strings/en_US.yaml
@@ -13,11 +13,13 @@ handlers:
     [{tracker_id}] Something went wrong, please contact a moderator with the provided ID.
 name_validator:
   valid_name: |
-    Hey <@{user_id}>, you are now successfully registered as **u/{username}**. Thank you!
+    Hey <@{user_id}>, you are now successfully registered as **/u/{username}**. Thank you!
   invalid_name: |
     Hey <@{user_id}>, it appears that your new server nickname is **not compliant** with our guidelines.
 
     It has to have the format `/u/<reddit_username>`, where you replace `<reddit_username>` with your actual username.
+  missing_slash_missing_permissions: |
+    Hey <@{user_id}>, you seem to be missing the leading slash in your server nickname, but I don't have sufficient permissions to fix it for you!
 find:
   please_check_url: |
     Please check that your link is correct; it should lead to either a post on r/TranscribersOfReddit, a post on a partner sub or to a transcription.

--- a/buttercup/strings/en_US.yaml
+++ b/buttercup/strings/en_US.yaml
@@ -17,7 +17,7 @@ name_validator:
   invalid_name: |
     Hey <@{user_id}>, it appears that your new server nickname is **not compliant** with our guidelines.
 
-    It has to have the format `/u/<reddit_username>`, where you replace `<reddit_username>` with your actual username.
+    It must have the format `/u/<reddit_username>`, where you replace `<reddit_username>` with your actual username.
   missing_slash_missing_permissions: |
     Hey <@{user_id}>, you seem to be missing the leading slash in your server nickname, but I don't have sufficient permissions to fix it for you!
 find:


### PR DESCRIPTION
Relevant issue: Closes #84

## Description:

This PR reworks the previous name validation system.
The previous approach of saving all usernames to a cache and using it to keep track of the changes was very error prone and didn't work when the bot was restarting.

The new approach is much simpler and just uses the old and new names provided by the member update event.
I also included an automatic fix if the user forgets to use the leading slash.

## Screenshots:

Response when username is valid:
![Hey **@/u/Tim3303 - UTC+1**, you are now successfully registered as **/u/Tim3303**. Thank you!](https://user-images.githubusercontent.com/13908946/143720286-e97685c4-2870-4e2d-8580-7bce30c9634c.png)

Response when username is invalid:
![Hey **@/u/Tim3303 - UTC+1**, it appears that your new server nickname is not compliant with our guidelines. It must have the format `/u/<reddit_username>`, where you replace `<reddit_username>` with your actual username.](https://user-images.githubusercontent.com/13908946/143720509-f74b840d-99b1-438a-9134-06ce202ed080.png)

## Future Work

- Only allow the `[mod]` tag in the display name for actual mods (#85)
- Check if the username exists on Blossom/Reddit (#86)
- Kick members automatically when the display name is invalid for 12 hours
- Also track username changes (from one valid display name to another, but the username changed)

## Checklist:

- [x] Code Quality
- [x] Pep-8
- [ ] Tests (if applicable)
- [x] Success Criteria Met
- [x] Inline Documentation
- [ ] Wiki Documentation (if applicable)
