### PR TITLE
Fix key error for until command, fix output when goal is reached

### DIFF
--- a/buttercup/cogs/history.py
+++ b/buttercup/cogs/history.py
@@ -749,7 +749,7 @@ class History(Cog):
             description = i18n["until"]["embed_description_zero"].format(
                 time_frame=get_timedelta_str(time_frame),
                 user=username,
-                cur_gamma=user["gamma"],
+                user_gamma=user["gamma"],
                 goal=goal_str,
             )
         else:

--- a/buttercup/cogs/history.py
+++ b/buttercup/cogs/history.py
@@ -727,7 +727,7 @@ class History(Cog):
                     duration=get_duration_str(start)
                 ),
                 embed=Embed(
-                    title=i18n["until"]["embed_title"].format(username),
+                    title=i18n["until"]["embed_title"].format(user=username),
                     description=i18n["until"]["embed_description_new"].format(
                         user=username
                     ),
@@ -745,7 +745,16 @@ class History(Cog):
             )
             return
 
-        if user_progress == 0:
+        if user["gamma"] >= goal_gamma:
+            # The user has already reached the goal
+            description = i18n["until"]["embed_description_reached"].format(
+                time_frame="week",
+                user=username,
+                user_gamma=user["gamma"],
+                goal=goal_str,
+                user_progress=user_progress,
+            )
+        elif user_progress == 0:
             description = i18n["until"]["embed_description_zero"].format(
                 time_frame=get_timedelta_str(time_frame),
                 user=username,

--- a/buttercup/strings/en_US.yaml
+++ b/buttercup/strings/en_US.yaml
@@ -206,8 +206,10 @@ until:
     Prediction for u/{user}
   embed_description_prediction: |
     **u/{user}** ({user_gamma}, {user_progress}/{time_frame}) will reach **{goal}** in {time_needed}!
+  embed_description_reached: |
+    **u/{user}** ({user_gamma}, {user_progress}/{time_frame}) has already reached **{goal}**!
   embed_description_zero: |
-    **u/{user}** will never get from {user_gamma} to **{goal}** at this pace, they haven't transcribed anything in the past {time_frame}!
+    **u/{user}** will **never** get from {user_gamma} to **{goal}** at this pace, they haven't transcribed anything in the past {time_frame}!
   embed_description_new: |
     Hey u/{user}!
     It looks like you haven't started transribing yet. Do you need any help to get started?


### PR DESCRIPTION
Relevant issue: Closes #104.

## Description:

- Fixes a `KeyError` when formatting the output of `/until` when the user hasn't transcribed anything recently.
- Fixes the output of `/until` when the user has already reached the goal.

## Screenshots:

The bot now gives a different message when the goal has already been reached:
![The bot responding to `/until`, saying that u/seeroflights has already reached Ruby.](https://user-images.githubusercontent.com/13908946/145489110-871300ef-70ca-4754-8684-ed1224a54bb6.png)

## Checklist:

- [x] Code Quality
- [x] Pep-8
- [ ] Tests (if applicable)
- [x] Success Criteria Met
- [x] Inline Documentation
- [ ] Wiki Documentation (if applicable)
