### PR TITLE
Add options for user and time filtering for `/search` command

### DIFF
--- a/buttercup/cogs/helpers.py
+++ b/buttercup/cogs/helpers.py
@@ -1,7 +1,7 @@
 import re
 from datetime import datetime, timedelta
 from time import mktime
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import pytz
 from blossom_wrapper import BlossomResponse
@@ -300,3 +300,14 @@ def get_rgb_from_hex(hex_str: str) -> Tuple[int, int, int]:
     # https://stackoverflow.com/questions/29643352/converting-hex-to-rgb-value-in-python
     hx = hex_str.lstrip("#")
     return int(hx[0:2], 16), int(hx[2:4], 16), int(hx[4:6], 16)
+
+
+def get_username(user: Optional[Dict[str, Any]]) -> str:
+    """Get the name of the given user.
+
+    None is interpreted as all users.
+    """
+    if user is None:
+        return "everybody"
+
+    return "u/" + user["username"]

--- a/buttercup/cogs/search.py
+++ b/buttercup/cogs/search.py
@@ -16,10 +16,11 @@ from discord_slash.utils.manage_commands import create_option
 from buttercup.bot import ButtercupBot
 from buttercup.cogs.helpers import (
     BlossomException,
-    get_duration_str,
-    parse_time_constraints,
-    extract_username,
     InvalidArgumentException,
+    extract_username,
+    get_duration_str,
+    get_username,
+    parse_time_constraints,
 )
 from buttercup.strings import translation
 
@@ -224,7 +225,8 @@ class Search(Cog):
 
         discord_page = cache_item["cur_page"] + page_mod
         query = cache_item["query"]
-        user_id = cache_item["user"]["id"] if cache_item["user"] else None
+        user = cache_item["user"]
+        user_id = user["id"] if user else None
         after_time = cache_item["after_time"]
         before_time = cache_item["before_time"]
         time_str = cache_item["time_str"]
@@ -259,7 +261,10 @@ class Search(Cog):
         if response_data["count"] == 0:
             await msg.edit(
                 content=i18n["search"]["no_results"].format(
-                    query=query, duration_str=get_duration_str(start)
+                    query=query,
+                    user=get_username(user),
+                    time_str=time_str,
+                    duration_str=get_duration_str(start),
                 )
             )
             return
@@ -297,10 +302,15 @@ class Search(Cog):
 
         await msg.edit(
             content=i18n["search"]["embed_message"].format(
-                query=query, duration_str=get_duration_str(start)
+                query=query,
+                user=get_username(user),
+                time_str=time_str,
+                duration_str=get_duration_str(start),
             ),
             embed=Embed(
-                title=i18n["search"]["embed_title"].format(query=query),
+                title=i18n["search"]["embed_title"].format(
+                    query=query, user=get_username(user)
+                ),
                 description=description,
             ).set_footer(
                 text=i18n["search"]["embed_footer"].format(

--- a/buttercup/strings/en_US.yaml
+++ b/buttercup/strings/en_US.yaml
@@ -277,7 +277,7 @@ leaderboard:
     Leaderboard for u/{user} ({time_frame})
 search:
   getting_search: |-
-    Searching for `{query}`...
+    Searching for `{query}` {time_str}...
   no_results: |-
     No results found for `{query}`. ({duration_str})
   description:

--- a/buttercup/strings/en_US.yaml
+++ b/buttercup/strings/en_US.yaml
@@ -279,15 +279,15 @@ search:
   getting_search: |-
     Searching for `{query}` {time_str}...
   no_results: |-
-    No results found for `{query}`. ({duration_str})
+    No results found for `{query}` by {user} {time_str}. ({duration_str})
   description:
     item: |-
       {num}. [{tr_type} on {tr_source}]({url})
     more_occurrences: |-
       ... and {count} more occurrence(s).
   embed_message: |-
-    Here are your results for `{query}`! ({duration_str})
+    Here are your results for `{query}` by {user} {time_str}! ({duration_str})
   embed_title: |-
-    Results for `{query}`
+    Results for `{query}` by {user}
   embed_footer: |-
     Page {cur_page}/{total_pages} ({total_results} result(s))


### PR DESCRIPTION
Relevant issue: Closes #106.

## Description:

This adds options to the `/search` command that allow to restrict the results to a specific user and time frame. The user executing the command will be the default user.

## Screenshots:

![Example of the `/search` command, filtered to u/Cloakknight and only considering transcriptions from 3 months ago until now.](https://user-images.githubusercontent.com/13908946/145553591-f349869f-27d8-49f4-9876-a240300dfcfa.png)


## Checklist:

- [x] Code Quality
- [x] Pep-8
- [ ] Tests (if applicable)
- [x] Success Criteria Met
- [x] Inline Documentation
- [ ] Wiki Documentation (if applicable)
