### PR TITLE
Adjust zoom for history graphs

### DIFF
--- a/buttercup/cogs/history.py
+++ b/buttercup/cogs/history.py
@@ -374,7 +374,8 @@ class History(Cog):
                 )
             )
 
-        user_gammas = []
+        min_gammas = []
+        max_gammas = []
 
         fig: plt.Figure = plt.figure()
         ax: plt.Axes = fig.gca()
@@ -406,9 +407,13 @@ class History(Cog):
             user_gamma, history_data = self.get_user_history(
                 user, after_time, before_time
             )
-            user_gammas.append(user_gamma)
+
             color = ranks[index]["color"]
+            first_point = history_data.iloc[0]
             last_point = history_data.iloc[-1]
+
+            min_gammas.append(first_point.at["gamma"])
+            max_gammas.append(last_point.at["gamma"])
 
             # Plot the graph
             ax.plot(
@@ -426,7 +431,7 @@ class History(Cog):
             )
 
         # Show ranks when you are close to them already
-        ax = add_milestone_lines(ax, ranks, max(user_gammas) * 1.4)
+        ax = add_milestone_lines(ax, ranks, max(max_gammas) * 1.4)
 
         if len(users) > 1:
             ax.legend([f"u/{user}" for user in users])


### PR DESCRIPTION
Relevant issue: Closes #59.

## Description:

The user can restrict the time frame that is considered when creating a `/history` graph.

The bot now does a much better job at the following:
- Filling in straight lines if the user didn't transcribe at the start or end of the time frame.
- "Zooming in" on the top part if the gamma doesn't start at zero. This provides a lot more detail for high-ranked users.
- The highest shown milestone/rank line is now calculated based on the highest point in the graph instead of the users total gamma.

## Screenshots:

Before:
![The `/history` graph for u/MurdoMaclachlan from 2 months ago until now, before the changes. The gamma axis starts at 0, even though the first point of the graph is at roughly 9000. This results in the history line being quite flat, and details being lost.](https://user-images.githubusercontent.com/13908946/145624324-b0e6682c-a8ed-45c6-8c46-fc9cd85ad200.png)

After:
![The `/history` graph for u/MurdoMaclachlan from 2 months ago until now, after the changes. The gamma axis now starts at about 9000, making a lot more details visible in the graph.](https://user-images.githubusercontent.com/13908946/145624133-a0332d95-0f8a-48ec-9c4a-9ff3001c5ebe.png)

## Checklist:

- [x] Code Quality
- [x] Pep-8
- [ ] Tests (if applicable)
- [x] Success Criteria Met
- [x] Inline Documentation
- [ ] Wiki Documentation (if applicable)
