### PR TITLE
Hotfix: Fix misconfigured timezones for rate calculation

### DIFF
--- a/buttercup/cogs/history.py
+++ b/buttercup/cogs/history.py
@@ -98,11 +98,15 @@ def add_zero_rates(
     """
     new_index = set()
     delta = get_timedelta_from_time_frame(time_frame)
-    now = datetime.now(tz=tzutc())
+    now = datetime.now(tz=pytz.utc)
 
     if after_time:
         # Add the earliest point according to the timeframe
         first_date = data.index[0]
+        # Make sure everything is localized
+        first_date = first_date.replace(tzinfo=first_date.tzinfo or pytz.utc)
+        after_time = after_time.replace(tzinfo=after_time.tzinfo or pytz.utc)
+
         missing_delta: timedelta = first_date - after_time
         missing_time_frames = missing_delta.total_seconds() // delta.total_seconds()
         if missing_time_frames > 0:
@@ -121,7 +125,12 @@ def add_zero_rates(
 
     # Add the latest point according to the timeframe
     last_date = data.index[-1]
-    missing_delta: timedelta = (before_time or now) - last_date
+    # Make sure everything is localized
+    last_date = last_date.replace(tzinfo=last_date.tzinfo or pytz.utc)
+    before_time = before_time or now
+    before_time = before_time.replace(tzinfo=before_time.tzinfo or pytz.utc)
+
+    missing_delta: timedelta = before_time - last_date
     missing_time_frames = missing_delta.total_seconds() // delta.total_seconds()
     if missing_time_frames > 0:
         # We need to add a new entry at the end


### PR DESCRIPTION
Relevant issue: N/A

## Description:

This is a hotfix for a Buttercup error, which occurred because a localized and an unlocalized timezone were used together in an equation.

I'm not sure if this will actually fix the bug, because I wasn't able to reproduce the issue locally.

Original error:

```
Dec 10 18:45:04 localhost python[19811]: TypeError: Timestamp subtraction must have the same timezones or no timezones
Dec 10 18:45:04 localhost python[19811]: 2021-12-10 18:45:04,160 | WARNING | [aeb28572-6b04-407b-9df7-50b8e193519a] TypeError: Timestamp subtraction must have the same timezones or no timezones
Dec 10 18:45:04 localhost python[19811]: Traceback (most recent call last):
Dec 10 18:45:04 localhost python[19811]:   File "/data/buttercup/.venv/lib/python3.9/site-packages/discord_slash/client.py", line 872, in invoke_command
Dec 10 18:45:04 localhost python[19811]:     await func.invoke(ctx, args)
Dec 10 18:45:04 localhost python[19811]:   File "/data/buttercup/.venv/lib/python3.9/site-packages/discord_slash/model.py", line 291, in invoke
Dec 10 18:45:04 localhost python[19811]:     return await coro
Dec 10 18:45:04 localhost python[19811]:   File "/data/buttercup/buttercup/cogs/history.py", line 411, in _history
Dec 10 18:45:04 localhost python[19811]:     user_gamma, history_data = self.get_user_history(
Dec 10 18:45:04 localhost python[19811]:   File "/data/buttercup/buttercup/cogs/history.py", line 313, in get_user_history
Dec 10 18:45:04 localhost python[19811]:     rate_data = self.get_all_rate_data(
Dec 10 18:45:04 localhost python[19811]:   File "/data/buttercup/buttercup/cogs/history.py", line 256, in get_all_rate_data
Dec 10 18:45:04 localhost python[19811]:     rate_data = add_zero_rates(rate_data, time_frame, after_time, before_time)
Dec 10 18:45:04 localhost python[19811]:   File "/data/buttercup/buttercup/cogs/history.py", line 106, in add_zero_rates
Dec 10 18:45:04 localhost python[19811]:     missing_delta: timedelta = first_date - after_time
Dec 10 18:45:04 localhost python[19811]:   File "pandas/_libs/tslibs/timestamps.pyx", line 348, in pandas._libs.tslibs.timestamps._Timestamp.__sub__
Dec 10 18:45:04 localhost python[19811]: TypeError: Timestamp subtraction must have the same timezones or no timezones
```

## Checklist:

- [x] Code Quality
- [x] Pep-8
- [ ] Tests (if applicable)
- [ ] Success Criteria Met
- [x] Inline Documentation
- [ ] Wiki Documentation (if applicable)
