### PR TITLE
Rework username handling

### DIFF
--- a/buttercup/cogs/handlers.py
+++ b/buttercup/cogs/handlers.py
@@ -11,6 +11,7 @@ from buttercup.cogs.helpers import (
     InvalidArgumentException,
     NoUsernameException,
     TimeParseError,
+    UserNotFoundException,
 )
 from buttercup.strings import translation
 
@@ -43,6 +44,11 @@ class Handlers(commands.Cog):
         elif isinstance(error, NoUsernameException):
             logger.warning("Command executed without providing a username.", ctx)
             await ctx.send(i18n["handlers"]["no_username"])
+        elif isinstance(error, UserNotFoundException):
+            logger.warning(f"User '{error.username}' not found.", ctx)
+            await ctx.send(
+                i18n["handlers"]["user_not_found"].format(user=error.username)
+            )
         elif isinstance(error, TimeParseError):
             logger.warning(
                 f"Command executed with an invalid time string '{error.time_str}'.", ctx

--- a/buttercup/cogs/helpers.py
+++ b/buttercup/cogs/helpers.py
@@ -1,10 +1,10 @@
 import re
 from datetime import datetime, timedelta
 from time import mktime
-from typing import Any, Dict, List, Optional, Tuple, Union, TypedDict
+from typing import Dict, List, Optional, Tuple, TypedDict, Union
 
 import pytz
-from blossom_wrapper import BlossomResponse, BlossomAPI, BlossomStatus
+from blossom_wrapper import BlossomAPI, BlossomResponse, BlossomStatus
 from dateutil import parser
 from discord import DiscordException, User
 from discord_slash import SlashContext
@@ -33,7 +33,7 @@ unit_regexes: Dict[str, re.Pattern] = {
 
 
 class BlossomUser(TypedDict):
-    id: int
+    id: int  # noqa: VNE003
     username: str
     gamma: int
     date_joined: str
@@ -163,9 +163,9 @@ def get_user(
 
     Special keywords:
     - "me": Returns the user executing the command (from the SlashContext).
-    - "all"/"everyone"/"everybody": Returns None, should return stats for all users if possible.
+    - "all"/"everyone"/"everybody": Stats for all users, returns None.
 
-    If the user could not be found, a UserNotFoundException is thrown and handled automatically.
+    If the user could not be found, a UserNotFoundException is thrown.
     """
     if username.casefold() in ["all", "everyone", "everybody"]:
         # Handle command execution for everyone
@@ -192,9 +192,9 @@ def get_user_list(
 
     Special keywords:
     - "me": Returns the user executing the command (from the SlashContext).
-    - "all"/"everyone"/"everybody": Returns None, should return stats for all users if possible.
+    - "all"/"everyone"/"everybody": Stats for all users, returns None.
 
-    If the user could not be found, a UserNotFoundException is thrown and handled automatically.
+    If the user could not be found, a UserNotFoundException is thrown.
     """
     username_input = usernames.split(" ")
     user_list = [get_user(user, ctx, blossom_api) for user in username_input]

--- a/buttercup/cogs/helpers.py
+++ b/buttercup/cogs/helpers.py
@@ -135,7 +135,9 @@ def get_initial_username(username: str, ctx: SlashContext) -> str:
     return "u/" + extract_username(_username)
 
 
-def get_user(username: str, ctx: SlashContext, blossom_api: BlossomAPI) -> Optional[BlossomUser]:
+def get_user(
+    username: str, ctx: SlashContext, blossom_api: BlossomAPI
+) -> Optional[BlossomUser]:
     """Get the given user from Blossom.
 
     Special keywords:
@@ -158,6 +160,49 @@ def get_user(username: str, ctx: SlashContext, blossom_api: BlossomAPI) -> Optio
         raise UserNotFoundException(_username)
 
     return user_response.data
+
+
+def get_initial_username_list(usernames: str, ctx: SlashContext) -> str:
+    """Get the initial, unverified string of multiple users.
+
+    The usernames should be separated with a space.
+
+    This does not make any API requests yet, so it can be used for the first message.
+
+    Special keywords:
+    - "me": Returns the user executing the command (from the SlashContext).
+    - "all"/"everyone"/"everybody": Returns "everyone".
+    """
+    username_input = usernames.split(" ")
+    username_set = set([get_initial_username(user, ctx) for user in username_input])
+
+    if "everyone" in username_set:
+        return "everyone"
+
+    # Connect the usernames
+    return join_items_with_and(list(username_set))
+
+
+def get_user_list(
+    usernames: str, ctx: SlashContext, blossom_api: BlossomAPI
+) -> Optional[List[BlossomUser]]:
+    """Get the given users from Blossom.
+
+    The usernames should be separated with a space.
+
+    Special keywords:
+    - "me": Returns the user executing the command (from the SlashContext).
+    - "all"/"everyone"/"everybody": Returns None, should return stats for all users if possible.
+
+    If the user could not be found, a UserNotFoundException is thrown and handled automatically.
+    """
+    username_input = usernames.split(" ")
+    user_set = set([get_user(user, ctx, blossom_api) for user in username_input])
+
+    if None in user_set:
+        return None
+
+    return list(user_set)
 
 
 def get_username(user: Optional[BlossomUser]) -> str:

--- a/buttercup/cogs/helpers.py
+++ b/buttercup/cogs/helpers.py
@@ -118,6 +118,23 @@ def get_usernames_from_user_list(
     return [extract_username(user) for user in raw_names][:limit]
 
 
+def get_initial_username(username: str, ctx: SlashContext) -> str:
+    """Get the initial, unverified username.
+
+    This does not make any API requests yet, so it can be used for the first message.
+
+    Special keywords:
+    - "me": Returns the user executing the command (from the SlashContext).
+    - "all"/"everyone"/"everybody": Returns "everyone".
+    """
+    if username.casefold() in ["all", "everyone", "everybody"]:
+        # Handle command execution for everyone
+        return "everyone"
+
+    _username = ctx.author.display_name if username.casefold() == "me" else username
+    return "u/" + extract_username(_username)
+
+
 def get_user(username: str, ctx: SlashContext, blossom_api: BlossomAPI) -> Optional[BlossomUser]:
     """Get the given user from Blossom.
 
@@ -132,7 +149,8 @@ def get_user(username: str, ctx: SlashContext, blossom_api: BlossomAPI) -> Optio
         return None
 
     # Handle command execution for the current user
-    _username = extract_username(ctx.author.display_name) if username.casefold() == "me" else username
+    _username = ctx.author.display_name if username.casefold() == "me" else username
+    _username = extract_username(_username)
 
     user_response = blossom_api.get_user(_username)
 

--- a/buttercup/cogs/helpers.py
+++ b/buttercup/cogs/helpers.py
@@ -1,7 +1,7 @@
 import re
 from datetime import datetime, timedelta
 from time import mktime
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union, TypedDict
 
 import pytz
 from blossom_wrapper import BlossomResponse
@@ -29,6 +29,13 @@ unit_regexes: Dict[str, re.Pattern] = {
     "months": re.compile(r"^m(?:onths?)?$"),
     "years": re.compile(r"^y(?:ears?)?$"),
 }
+
+
+class BlossomUser(TypedDict):
+    id: int
+    username: str
+    gamma: int
+    date_joined: str
 
 
 class NoUsernameException(DiscordException):
@@ -302,7 +309,7 @@ def get_rgb_from_hex(hex_str: str) -> Tuple[int, int, int]:
     return int(hx[0:2], 16), int(hx[2:4], 16), int(hx[4:6], 16)
 
 
-def get_username(user: Optional[Dict[str, Any]]) -> str:
+def get_username(user: Optional[BlossomUser]) -> str:
     """Get the name of the given user.
 
     None is interpreted as all users.

--- a/buttercup/cogs/helpers.py
+++ b/buttercup/cogs/helpers.py
@@ -160,6 +160,22 @@ def get_user(username: str, ctx: SlashContext, blossom_api: BlossomAPI) -> Optio
     return user_response.data
 
 
+def get_username(user: Optional[BlossomUser]) -> str:
+    """Get the name of the given user.
+
+    None is interpreted as all users.
+    """
+    return "u/" + user["username"] if user else "everyone"
+
+
+def get_user_id(user: Optional[BlossomUser]) -> Optional[int]:
+    """Get the ID of the given user.
+
+    None is interpreted as all users and will also return None.
+    """
+    return user["id"] if user else None
+
+
 def extract_sub_name(subreddit: str) -> str:
     """Extract the name of the sub without prefix."""
     if subreddit.startswith("/r/"):
@@ -359,14 +375,3 @@ def get_rgb_from_hex(hex_str: str) -> Tuple[int, int, int]:
     # https://stackoverflow.com/questions/29643352/converting-hex-to-rgb-value-in-python
     hx = hex_str.lstrip("#")
     return int(hx[0:2], 16), int(hx[2:4], 16), int(hx[4:6], 16)
-
-
-def get_username(user: Optional[BlossomUser]) -> str:
-    """Get the name of the given user.
-
-    None is interpreted as all users.
-    """
-    if user is None:
-        return "everybody"
-
-    return "u/" + user["username"]

--- a/buttercup/cogs/history.py
+++ b/buttercup/cogs/history.py
@@ -32,8 +32,6 @@ from buttercup.cogs.helpers import (
     get_user_list,
     get_username,
     get_usernames,
-    get_usernames_from_user_list,
-    join_items_with_and,
     parse_time_constraints,
 )
 from buttercup.strings import translation

--- a/buttercup/cogs/leaderboard.py
+++ b/buttercup/cogs/leaderboard.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from typing import Any, Dict, Optional
 
 import pytz
-from blossom_wrapper import BlossomAPI, BlossomStatus
+from blossom_wrapper import BlossomAPI
 from discord import Colour, Embed
 from discord.ext.commands import Cog
 from discord_slash import SlashContext, cog_ext
@@ -11,12 +11,14 @@ from discord_slash.utils.manage_commands import create_option
 from buttercup.bot import ButtercupBot
 from buttercup.cogs.helpers import (
     BlossomException,
-    InvalidArgumentException,
-    extract_username,
     get_duration_str,
+    get_initial_username,
     get_rank,
     get_rgb_from_hex,
     get_timedelta_str,
+    get_user,
+    get_user_id,
+    get_username,
     parse_time_constraints,
 )
 from buttercup.strings import translation
@@ -79,31 +81,26 @@ class Leaderboard(Cog):
     async def leaderboard(
         self,
         ctx: SlashContext,
-        username: Optional[str] = None,
+        username: str = "me",
         after: Optional[str] = None,
         before: Optional[str] = None,
     ) -> None:
         """Get the leaderboard for the given user."""
         start = datetime.now(tz=pytz.utc)
 
-        username = username or extract_username(ctx.author.display_name)
         after_time, before_time, time_str = parse_time_constraints(after, before)
 
         # Send a first message to show that the bot is responsive.
         # We will edit this message later with the actual content.
         msg = await ctx.send(
             i18n["leaderboard"]["getting_leaderboard"].format(
-                user=username, time_str=time_str
+                user=get_initial_username(username, ctx), time_str=time_str
             )
         )
 
-        volunteer_response = self.blossom_api.get_user(username)
-        if volunteer_response.status != BlossomStatus.ok:
-            raise InvalidArgumentException("username", username)
-        user = volunteer_response.data
-        username = user["username"]
+        user = get_user(username, ctx, self.blossom_api)
 
-        top_count = 5
+        top_count = 5 if user else 15
         context_count = 5
 
         from_str = after_time.isoformat() if after_time else None
@@ -113,7 +110,7 @@ class Leaderboard(Cog):
         leaderboard_response = self.blossom_api.get(
             "submission/leaderboard",
             params={
-                "user_id": user["id"],
+                "user_id": get_user_id(user),
                 "top_count": top_count,
                 "below_count": context_count,
                 "above_count": context_count,
@@ -123,6 +120,7 @@ class Leaderboard(Cog):
         )
         if leaderboard_response.status_code != 200:
             raise BlossomException(leaderboard_response)
+
         leaderboard = leaderboard_response.json()
         # Extract needed data
         top_users = leaderboard["top"]
@@ -134,38 +132,48 @@ class Leaderboard(Cog):
 
         # Only show the top users if they are not already included
         top_user_limit = (
-            above_users[0]["rank"] if len(above_users) > 0 else lb_user["rank"]
+            top_count + 1
+            if user is None
+            else above_users[0]["rank"]
+            if len(above_users) > 0
+            else lb_user["rank"]
         )
 
         # Show top users
         for top_user in top_users[: top_user_limit - 1]:
             description += format_leaderboard_user(top_user) + "\n"
 
-        # Add separator if necessary
-        if top_user_limit > top_count + 1:
-            description += "...\n"
+        rank = get_rank(top_users[0]["gamma"])
 
-        # Show users with more gamma than the current user
-        for above_user in above_users:
-            description += format_leaderboard_user(above_user) + "\n"
+        if user:
+            # Add separator if necessary
+            if top_user_limit > top_count + 1:
+                description += "...\n"
 
-        # Show the current user
-        description += "**" + format_leaderboard_user(lb_user) + "**\n"
+            # Show users with more gamma than the current user
+            for above_user in above_users:
+                description += format_leaderboard_user(above_user) + "\n"
 
-        # Show users with less gamma than the current user
-        for below_user in below_users:
-            description += format_leaderboard_user(below_user) + "\n"
+            # Show the current user
+            description += "**" + format_leaderboard_user(lb_user) + "**\n"
 
-        rank = get_rank(user["gamma"])
+            # Show users with less gamma than the current user
+            for below_user in below_users:
+                description += format_leaderboard_user(below_user) + "\n"
+
+            rank = get_rank(user["gamma"])
+
         time_frame = format_leaderboard_timeframe(after_time, before_time)
 
         await msg.edit(
             content=i18n["leaderboard"]["embed_message"].format(
-                user=username, time_str=time_str, duration=get_duration_str(start)
+                user=get_username(user),
+                time_str=time_str,
+                duration=get_duration_str(start),
             ),
             embed=Embed(
                 title=i18n["leaderboard"]["embed_title"].format(
-                    user=username, time_frame=time_frame
+                    user=get_username(user), time_frame=time_frame
                 ),
                 description=description,
                 color=Colour.from_rgb(*get_rgb_from_hex(rank["color"])),

--- a/buttercup/cogs/search.py
+++ b/buttercup/cogs/search.py
@@ -20,7 +20,7 @@ from buttercup.cogs.helpers import (
     extract_username,
     get_duration_str,
     get_username,
-    parse_time_constraints,
+    parse_time_constraints, BlossomUser,
 )
 from buttercup.strings import translation
 
@@ -133,7 +133,7 @@ class SearchCacheItem(TypedDict):
     # The query that the user searched for
     query: str
     # The user that the search is restricted to
-    user: Optional[Dict[str, Any]]
+    user: Optional[BlossomUser]
     # The time restriction for the search
     after_time: Optional[datetime]
     before_time: Optional[datetime]

--- a/buttercup/cogs/search.py
+++ b/buttercup/cogs/search.py
@@ -16,11 +16,12 @@ from discord_slash.utils.manage_commands import create_option
 from buttercup.bot import ButtercupBot
 from buttercup.cogs.helpers import (
     BlossomException,
+    BlossomUser,
     InvalidArgumentException,
     extract_username,
     get_duration_str,
     get_username,
-    parse_time_constraints, BlossomUser,
+    parse_time_constraints,
 )
 from buttercup.strings import translation
 

--- a/buttercup/cogs/stats.py
+++ b/buttercup/cogs/stats.py
@@ -9,16 +9,23 @@ from dateutil.parser import parse
 from discord import Embed
 from discord.ext.commands import Cog
 from discord_slash import SlashContext, cog_ext
+from discord_slash.model import SlashMessage
 from discord_slash.utils.manage_commands import create_option
 
 from buttercup.bot import ButtercupBot
 from buttercup.cogs.helpers import (
+    BlossomException,
+    BlossomUser,
     extract_username,
     get_discord_time_str,
     get_duration_str,
+    get_initial_username,
     get_progress_bar,
     get_rank,
     get_rgb_from_hex,
+    get_user,
+    get_user_id,
+    get_username,
     parse_time_constraints,
 )
 from buttercup.strings import translation
@@ -26,7 +33,7 @@ from buttercup.strings import translation
 i18n = translation()
 
 
-def get_motivational_message(user: str, progress_count: int) -> str:
+def get_motivational_message(user: Optional[BlossomUser], progress_count: int) -> str:
     """Determine the motivational message for the current progress."""
     all_messages = i18n["progress"]["motivational_messages"]
     message_set = []
@@ -38,7 +45,7 @@ def get_motivational_message(user: str, progress_count: int) -> str:
             break
 
     # Select a random message
-    return choice(message_set).format(user=user)
+    return choice(message_set).format(user=get_username(user))
 
 
 class Stats(Cog):
@@ -60,62 +67,62 @@ class Stats(Cog):
             )
         ],
     )
-    async def _stats(self, ctx: SlashContext, username: Optional[str] = None) -> None:
+    async def _stats(self, ctx: SlashContext, username: str = "me") -> None:
         """Get the stats about one or all users."""
-        if username is not None and username.strip().casefold() == "all":
-            # If "all" is provided as username, return the global stats
-            await self._all_stats(ctx)
-        else:
-            await self._user_stats(ctx, username)
+        initial_username = get_initial_username(username, ctx)
 
-    async def _all_stats(self, ctx: SlashContext) -> None:
-        """Get stats about all users."""
         # Send a first message to show that the bot is responsive.
         # We will edit this message later with the actual content.
-        msg = await ctx.send(i18n["stats"]["getting_stats"])
+        msg = await ctx.send(
+            i18n["stats"]["getting_stats"].format(user=initial_username)
+        )
+
+        if initial_username == get_username(None):
+            # Global stats
+            await self._all_stats(msg)
+        else:
+            await self._user_stats(ctx, msg, username)
+
+    async def _all_stats(self, msg: SlashMessage) -> None:
+        """Get stats about all users."""
+        start = datetime.now(tz=pytz.utc)
 
         response = self.blossom_api.get("summary/")
 
         if response.status_code != 200:
-            await msg.edit(content=i18n["stats"]["failed_getting_stats"])
-            return
+            raise BlossomException(response)
 
         data = response.json()
 
-        description = i18n["stats"]["embed_description"].format(
-            data["volunteer_count"],
-            data["transcription_count"],
-            data["days_since_inception"],
+        description = i18n["stats"]["embed_description_all"].format(
+            volunteers=data["volunteer_count"],
+            transcriptions=data["transcription_count"],
+            days=data["days_since_inception"],
         )
 
         await msg.edit(
-            content=i18n["stats"]["embed_message"],
-            embed=Embed(title=i18n["stats"]["embed_title"], description=description),
+            content=i18n["stats"]["embed_message"].format(
+                user=get_username(None), duration=get_duration_str(start)
+            ),
+            embed=Embed(
+                title=i18n["stats"]["embed_title"].format(user=get_username(None)),
+                description=description,
+            ),
         )
 
     async def _user_stats(
-        self, ctx: SlashContext, username: Optional[str] = None
+        self, ctx: SlashContext, msg: SlashMessage, username: str
     ) -> None:
         """Get stats about a single user."""
         start = datetime.now(tz=pytz.utc)
-        user = username or extract_username(ctx.author.display_name)
-        # Send a first message to show that the bot is responsive.
-        # We will edit this message later with the actual content.
-        msg = await ctx.send(i18n["user_stats"]["getting_stats"].format(user=user))
 
-        volunteer_response = self.blossom_api.get_user(user)
-        if volunteer_response.status != BlossomStatus.ok:
-            await msg.edit(
-                content=i18n["user_stats"]["failed_getting_stats"].format(user=user)
-            )
-            return
-        volunteer_data = volunteer_response.data
+        user = get_user(username, ctx, self.blossom_api)
 
         # Get the date of last activity
         submission_response = self.blossom_api.get(
             "submission/",
             params={
-                "completed_by": volunteer_data["id"],
+                "completed_by": get_user_id(user),
                 "ordering": "-complete_time",
                 "complete_time__isnull": False,
                 "page_size": 1,
@@ -123,13 +130,11 @@ class Stats(Cog):
             },
         )
         if submission_response.status_code != 200:
-            await msg.edit(
-                content=i18n["user_stats"]["failed_getting_stats"].format(user=user)
-            )
-            return
+            raise BlossomException(submission_response)
+
         submission_data = submission_response.json()["results"][0]
 
-        date_joined = parse(volunteer_data["date_joined"])
+        date_joined = parse(user["date_joined"])
         # For some reason, the complete_time is sometimes None, so we have to fall back
         last_active = parse(
             submission_data["complete_time"]
@@ -137,10 +142,10 @@ class Stats(Cog):
             or submission_data["create_time"]
         )
 
-        rank = get_rank(volunteer_data["gamma"])
+        rank = get_rank(user["gamma"])
 
-        description = i18n["user_stats"]["embed_description"].format(
-            gamma=volunteer_data["gamma"],
+        description = i18n["stats"]["embed_description_user"].format(
+            gamma=user["gamma"],
             flair_rank=rank["name"],
             date_joined=get_discord_time_str(date_joined),
             joined_ago=get_discord_time_str(date_joined, "R"),
@@ -149,11 +154,11 @@ class Stats(Cog):
         )
 
         await msg.edit(
-            content=i18n["user_stats"]["embed_message"].format(
-                user=user, duration=get_duration_str(start)
+            content=i18n["stats"]["embed_message"].format(
+                user=get_username(user), duration=get_duration_str(start)
             ),
             embed=Embed(
-                title=i18n["user_stats"]["embed_title"].format(user=user),
+                title=i18n["stats"]["embed_title"].format(user=get_username(user)),
                 color=discord.Colour.from_rgb(*get_rgb_from_hex(rank["color"])),
                 description=description,
             ),

--- a/buttercup/cogs/stats.py
+++ b/buttercup/cogs/stats.py
@@ -4,7 +4,7 @@ from typing import Optional
 
 import discord
 import pytz
-from blossom_wrapper import BlossomAPI, BlossomStatus
+from blossom_wrapper import BlossomAPI
 from dateutil.parser import parse
 from discord import Embed
 from discord.ext.commands import Cog
@@ -16,7 +16,6 @@ from buttercup.bot import ButtercupBot
 from buttercup.cogs.helpers import (
     BlossomException,
     BlossomUser,
-    extract_username,
     get_discord_time_str,
     get_duration_str,
     get_initial_username,
@@ -267,7 +266,8 @@ class Stats(Cog):
         )
 
         if not is_24_hours or not user:
-            # If it isn't 24 or if it's the global stats we can't really display a progress bar
+            # If it isn't 24 hours or if it's the global stats
+            # a progress bar doesn't make sense
             await msg.edit(
                 content=i18n["progress"]["embed_message"].format(
                     user=get_username(user), duration=get_duration_str(start),

--- a/buttercup/strings/en_US.yaml
+++ b/buttercup/strings/en_US.yaml
@@ -259,12 +259,11 @@ history:
     response_message:
       Here is the history graph for {users} {time_str}! ({duration})
 rate:
-    getting_rate_single: |
-      Creating the transcription rate graph for u/{user} {time_str}...
-    getting_rate_multi: |
+    getting_rate: |
+      Creating the transcription rate graph for {users} {time_str}...
+    getting_rate_progress: |
       Creating the transcription rate graph for {users} {time_str} ({count}/{total})...
-    plot_title_single: Transcription Rate of u/{user}
-    plot_title_multi: Transcription Rate of Multiple Users
+    plot_title: Transcription Rate of {users}
     plot_xlabel: Time
     plot_ylabel: Transcription Rate
     response_message:

--- a/buttercup/strings/en_US.yaml
+++ b/buttercup/strings/en_US.yaml
@@ -35,27 +35,16 @@ find:
   discord_username_link: "[{0}](https://reddit.com/u/{0})"
 stats:
   getting_stats: |
-    Getting stats for all users...
-  failed_getting_stats: |
-    Failed to get the stats for all users.
+    Getting stats for {user}...
   embed_message: |
-    Here are the stats!
+    Here are the stats for {user}! ({duration})
   embed_title: |
-    Stats For All Users
-  embed_description: |
-    **Volunteers**: {:,d}
-    **Transcriptions**: {:,d}
-    **Days Since Inception**: {:,d}
-user_stats:
-  getting_stats: |
-    Getting stats for u/{user}...
-  failed_getting_stats: |
-    Failed to get the stats for u/{user}.
-  embed_message: |
-    Here are the stats for u/{user}! ({duration})
-  embed_title: |
-    Stats for u/{user}
-  embed_description: |
+    Stats for {user}
+  embed_description_all: |
+    **Volunteers**: {volunteers:,d}
+    **Transcriptions**: {transcriptions:,d}
+    **Days Since Inception**: {days:,d}
+  embed_description_user: |
     **Transcriptions**: {gamma:,d}
     **Flair Rank**: {flair_rank}
     **Date Joined**: {date_joined} ({joined_ago})

--- a/buttercup/strings/en_US.yaml
+++ b/buttercup/strings/en_US.yaml
@@ -51,15 +51,13 @@ stats:
     **Last Active**: {last_active} ({last_ago})
 progress:
   getting_progress: |
-    Getting progress for u/{user} {time_str}...
+    Getting progress of {user} {time_str}...
   user_not_found: |
-    I couldn't find user u/{0}!
-  failed_getting_progress: |
-    I couldn't get the progress of u/{0}!
+    I couldn't find user {user}!
   embed_message: |
-    Here is the progress! ({0})
+    Here is the progress of {user}! ({duration})
   embed_title: |
-    Progress of u/{0}
+    Progress of {user}
   embed_description_24: |
     `{bar}` {count}/{total} transcriptions {time_str}.
 

--- a/buttercup/strings/en_US.yaml
+++ b/buttercup/strings/en_US.yaml
@@ -144,9 +144,7 @@ progress:
       - Is that a 500/24 or is the progress bar just happy to see me?
 heatmap:
   getting_heatmap: |
-    Generating a heatmap for u/{user} {time_str}...
-  user_not_found: |
-    Sorry, I couldn't find the user u/{0}.
+    Generating a heatmap for {user} {time_str}...
   days:
     - Mon
     - Tue
@@ -155,11 +153,11 @@ heatmap:
     - Fri
     - Sat
     - Sun
-  plot_title: Activity Heatmap for u/{0}
-  plot_xlabel: Time ({0})
+  plot_title: Activity Heatmap for {user}
+  plot_xlabel: Time ({timezone})
   plot_ylabel: Weekday
   response_message: |
-    Here is the heatmap for u/{user} {time_str}! ({duration})
+    Here is the heatmap for {user} {time_str}! ({duration})
 rules:
   getting_rules: |
     Getting the rules for r/{0}...

--- a/buttercup/strings/en_US.yaml
+++ b/buttercup/strings/en_US.yaml
@@ -270,11 +270,11 @@ rate:
       Here is the transcription rate graph for {usernames} {time_str}! ({duration})
 leaderboard:
   getting_leaderboard: |
-    Getting leaderboard for u/{user} {time_str}...
+    Getting leaderboard for {user} {time_str}...
   embed_message: |
-    Here is the leaderboard for u/{user} {time_str}! ({duration})
+    Here is the leaderboard for {user} {time_str}! ({duration})
   embed_title: |
-    Leaderboard for u/{user} ({time_frame})
+    Leaderboard for {user} ({time_frame})
 search:
   getting_search: |-
     Searching for `{query}` {time_str}...

--- a/buttercup/strings/en_US.yaml
+++ b/buttercup/strings/en_US.yaml
@@ -3,6 +3,8 @@ handlers:
     You are not authorized to use this command. This incident will be reported.
   no_username: |
     You did not provide a valid username. Either add it to the command or change your display name to a valid format.
+  user_not_found: |
+    I couldn't find a user with the name u/{user}!
   invalid_time_str: |
     "{time_str}" is an invalid date/time. Try something like "2021-08-04", "10:13" or "3 weeks ago".
   invalid_argument: |

--- a/buttercup/strings/en_US.yaml
+++ b/buttercup/strings/en_US.yaml
@@ -249,16 +249,15 @@ partner:
   embed_partner_status_description: |
     {status}
 history:
-    getting_history_single: |
-      Creating the history graph for u/{user} {time_str}...
-    getting_history_multi: |
+    getting_history: |
+      Creating the history graph for {users} {time_str}...
+    getting_history_progress: |
       Creating the history graph for {users} {time_str} ({count}/{total})...
-    plot_title_single: History of u/{user}
-    plot_title_multi: History of Multiple Users
+    plot_title: History of {users}
     plot_xlabel: Time
     plot_ylabel: Gamma
     response_message:
-      Here is the history graph for {usernames} {time_str}! ({duration})
+      Here is the history graph for {users} {time_str}! ({duration})
 rate:
     getting_rate_single: |
       Creating the transcription rate graph for u/{user} {time_str}...


### PR DESCRIPTION
Relevant issue: Closes #112.

## Description:

This is a major rework to simplify the process of validating usernames and getting the user data from Blossom.
This has several advantages:

- Consistency across all commands.
- Reduced code duplication, better error handling.
- We get some new features for "free", because we can always handle keywords like `me` and `all` for the username.

The `/heatmap`, `/leaderboard` and `/progress` commands can now also take the `all` keyword to show the stats for the whole ToR community. 

After merging this, all commands should be tested extensively to ensure that no formatting key errors or other bugs have sneaked in.

## Checklist:

- [x] Code Quality
- [x] Pep-8
- [x] Tests (if applicable)
- [x] Success Criteria Met
- [x] Inline Documentation
- [ ] Wiki Documentation (if applicable)
