### PR TITLE
Escape Discord formatting in usernames

### DIFF
--- a/buttercup/cogs/helpers.py
+++ b/buttercup/cogs/helpers.py
@@ -97,7 +97,7 @@ def extract_username(display_name: str) -> str:
 
 
 def get_usernames_from_user_list(
-    user_list: Optional[str], author: Optional[User], limit: int = 5
+    user_list: Optional[str], author: Optional[User], limit: int = 5,
 ) -> List[str]:
     """Get the individual usernames from a list of users.
 
@@ -118,6 +118,11 @@ def get_usernames_from_user_list(
     return [extract_username(user) for user in raw_names][:limit]
 
 
+def escape_formatting(username: str) -> str:
+    """Escapes Discord formatting in the given string."""
+    return username.replace("_", "\\_").replace("*", "\\*")
+
+
 def get_initial_username(username: str, ctx: SlashContext) -> str:
     """Get the initial, unverified username.
 
@@ -132,7 +137,7 @@ def get_initial_username(username: str, ctx: SlashContext) -> str:
         return "everyone"
 
     _username = ctx.author.display_name if username.casefold() == "me" else username
-    return "u/" + extract_username(_username)
+    return "u/" + escape_formatting(extract_username(_username))
 
 
 def get_initial_username_list(usernames: str, ctx: SlashContext) -> str:
@@ -215,11 +220,7 @@ def get_username(user: Optional[BlossomUser], escape: bool = True) -> str:
     """
     if not user:
         return "everyone"
-    username = (
-        user["username"].replace("_", "\\_").replace("*", "\\*")
-        if escape
-        else user["username"]
-    )
+    username = escape_formatting(user["username"]) if escape else user["username"]
     return "u/" + username
 
 

--- a/buttercup/cogs/helpers.py
+++ b/buttercup/cogs/helpers.py
@@ -205,16 +205,26 @@ def get_user_list(
     return user_list
 
 
-def get_username(user: Optional[BlossomUser]) -> str:
+def get_username(user: Optional[BlossomUser], escape: bool = True) -> str:
     """Get the name of the given user.
 
-    None is interpreted as all users.
+    :param user: The user to get the username of.
+        None is interpreted as all users.
+    :param escape: Whether the Discord formatting should be escaped.
+        Defaults to True.
     """
-    return "u/" + user["username"] if user else "everyone"
+    if not user:
+        return "everyone"
+    username = (
+        user["username"].replace("_", "\\_").replace("*", "\\*")
+        if escape
+        else user["username"]
+    )
+    return "u/" + username
 
 
 def get_usernames(
-    users: Optional[List[BlossomUser]], limit: Optional[int] = None
+    users: Optional[List[BlossomUser]], limit: Optional[int] = None, escape: bool = True
 ) -> str:
     """Get the name of the given users.
 
@@ -225,7 +235,7 @@ def get_usernames(
     if limit is not None and len(users) > limit:
         return f"{len(users)} users"
 
-    return join_items_with_and([get_username(user) for user in users])
+    return join_items_with_and([get_username(user, escape) for user in users])
 
 
 def get_user_id(user: Optional[BlossomUser]) -> Optional[int]:

--- a/buttercup/cogs/history.py
+++ b/buttercup/cogs/history.py
@@ -381,7 +381,9 @@ class History(Cog):
             label.set_ha("right")
 
         ax.set_title(
-            i18n["history"]["plot_title"].format(users=get_usernames(users, 2))
+            i18n["history"]["plot_title"].format(
+                users=get_usernames(users, 2, escape=False)
+            )
         )
 
         for index, user in enumerate(users):
@@ -427,7 +429,7 @@ class History(Cog):
         ax = add_milestone_lines(ax, ranks, min_value, max_value, delta)
 
         if len(users) > 1:
-            ax.legend([get_username(user) for user in users])
+            ax.legend([get_username(user, escape=False) for user in users])
 
         discord_file = create_file_from_figure(fig, "history_plot.png")
 
@@ -522,7 +524,11 @@ class History(Cog):
             label.set_rotation(32)
             label.set_ha("right")
 
-        ax.set_title(i18n["rate"]["plot_title"].format(users=get_usernames(users, 2)))
+        ax.set_title(
+            i18n["rate"]["plot_title"].format(
+                users=get_usernames(users, 2, escape=False)
+            )
+        )
 
         for index, user in enumerate(users):
             if len(users) > 1:
@@ -565,7 +571,7 @@ class History(Cog):
         ax = add_milestone_lines(ax, milestones, 0, max(max_rates), 40)
 
         if len(users) > 1:
-            ax.legend([get_username(user) for user in users])
+            ax.legend([get_username(user, escape=False) for user in users])
 
         discord_file = create_file_from_figure(fig, "rate_plot.png")
 
@@ -667,7 +673,7 @@ class History(Cog):
                 duration=get_duration_str(start)
             ),
             embed=Embed(
-                title=i18n["until"]["embed_title"].format(user=user["username"]),
+                title=i18n["until"]["embed_title"].format(user=get_username(user)),
                 description=description,
                 color=discord.Colour.from_rgb(*get_rgb_from_hex(color)),
             ),

--- a/test/test_helpers.py
+++ b/test/test_helpers.py
@@ -13,7 +13,7 @@ from buttercup.cogs.helpers import (
     get_progress_bar,
     join_items_with_and,
     parse_time_constraints,
-    try_parse_time,
+    try_parse_time, get_username, BlossomUser,
 )
 
 
@@ -45,6 +45,46 @@ def test_extract_username(user_input: str, expected: str) -> None:
 def test_extract_sub_name(sub_input: str, expected: str) -> None:
     """Test that the sub name is extracted correctly."""
     actual = extract_sub_name(sub_input)
+    assert actual == expected
+
+
+def test_get_username_none() -> None:
+    """Test that the username of a None object is returned correctly."""
+    actual = get_username(None)
+    assert actual == "everyone"
+
+
+def test_get_username_object() -> None:
+    """Test that the username of a None object is returned correctly."""
+    user: BlossomUser = {
+        "id": 1314,
+        "username": "abc",
+        "gamma": 110,
+        "date_joined": "2021-12-12T16:06Z"
+    }
+    actual = get_username(user)
+    assert actual == "u/abc"
+
+@mark.parametrize(
+    "username,expected",
+    [
+        ("user", r"u/user"),
+        ("_Diabetes", r"u/\_Diabetes"),
+        ("test*test*test", r"u/test\*test\*test"),
+        ("**bold**", r"u/\*\*bold\*\*"),
+        ("**bold**", r"u/\*\*bold\*\*"),
+        ("__BlAzEsUpErBlAzE__", r"u/\_\_BlAzEsUpErBlAzE\_\_"),
+    ],
+)
+def test_get_username_escaping(username: str, expected: str) -> None:
+    """Test that Discord formatting is escaped properly."""
+    user: BlossomUser = {
+        "id": 1314,
+        "username": username,
+        "gamma": 110,
+        "date_joined": "2021-12-12T16:06Z"
+    }
+    actual = get_username(user)
     assert actual == expected
 
 

--- a/test/test_helpers.py
+++ b/test/test_helpers.py
@@ -5,15 +5,18 @@ import pytz
 from pytest import mark
 
 from buttercup.cogs.helpers import (
+    BlossomUser,
+    escape_formatting,
     extract_sub_name,
     extract_username,
     extract_utc_offset,
     format_absolute_datetime,
     format_relative_datetime,
     get_progress_bar,
+    get_username,
     join_items_with_and,
     parse_time_constraints,
-    try_parse_time, get_username, BlossomUser,
+    try_parse_time,
 )
 
 
@@ -60,31 +63,26 @@ def test_get_username_object() -> None:
         "id": 1314,
         "username": "abc",
         "gamma": 110,
-        "date_joined": "2021-12-12T16:06Z"
+        "date_joined": "2021-12-12T16:06Z",
     }
     actual = get_username(user)
     assert actual == "u/abc"
 
+
 @mark.parametrize(
     "username,expected",
     [
-        ("user", r"u/user"),
-        ("_Diabetes", r"u/\_Diabetes"),
-        ("test*test*test", r"u/test\*test\*test"),
-        ("**bold**", r"u/\*\*bold\*\*"),
-        ("**bold**", r"u/\*\*bold\*\*"),
-        ("__BlAzEsUpErBlAzE__", r"u/\_\_BlAzEsUpErBlAzE\_\_"),
+        ("user", r"user"),
+        ("_Diabetes", r"\_Diabetes"),
+        ("test*test*test", r"test\*test\*test"),
+        ("**bold**", r"\*\*bold\*\*"),
+        ("**bold**", r"\*\*bold\*\*"),
+        ("__BlAzEsUpErBlAzE__", r"\_\_BlAzEsUpErBlAzE\_\_"),
     ],
 )
-def test_get_username_escaping(username: str, expected: str) -> None:
+def test_escape_formatting(username: str, expected: str) -> None:
     """Test that Discord formatting is escaped properly."""
-    user: BlossomUser = {
-        "id": 1314,
-        "username": username,
-        "gamma": 110,
-        "date_joined": "2021-12-12T16:06Z"
-    }
-    actual = get_username(user)
+    actual = escape_formatting(username)
     assert actual == expected
 
 


### PR DESCRIPTION
Relevant issue: Closes #101.

## Description:

In some circumstances, usernames containing Reddit formatting, such as `__TestUser__` would not render properly in the bot responses. This PR properly escapes the usernames to fix that.

## Checklist:

- [x] Code Quality
- [x] Pep-8
- [x] Tests (if applicable)
- [x] Success Criteria Met
- [x] Inline Documentation
- [ ] Wiki Documentation (if applicable)
