### PR TITLE
Add option to use history and rate with all users

### DIFF
--- a/buttercup/cogs/history.py
+++ b/buttercup/cogs/history.py
@@ -286,7 +286,7 @@ class History(Cog):
         else:
             # We need to get the total gamma of all users
             gamma_response = self.blossom_api.get(
-                "submission/", params={"page_size": 1},
+                "submission/", params={"page_size": 1, "completed_by__isnull": False},
             )
             if not gamma_response.ok:
                 raise BlossomException(gamma_response)
@@ -297,6 +297,7 @@ class History(Cog):
             offset_response = self.blossom_api.get(
                 "submission/",
                 params={
+                    "completed_by__isnull": False,
                     "completed_by": get_user_id(user),
                     "from": before_time.isoformat(),
                     "page_size": 1,


### PR DESCRIPTION
Relevant issue: Closes #116

## Description:

This enables the use of keywords like `all` for the username of the `/history` and `/rate` commands to get the stats for all users.

It's not perfect yet, because of some submissions without a proper date, the rate graph has a huge spike at some point.

Also the data granularity should be chosen properly to reduce losing times.

## Screenshots:

![The `/history` command for all users.](https://user-images.githubusercontent.com/13908946/145731882-e2c80046-4da5-48e3-b160-221032e412e6.png)

![The `/rate` command for all users. It has a huge spike with over 5000 gamma at about 2021-06.](https://user-images.githubusercontent.com/13908946/145731858-71235738-6902-40a4-9b4e-44d4aaccf327.png)

![The `/rate` command for all users from 2 months ago until now.](https://user-images.githubusercontent.com/13908946/145731835-3bc6b475-dfb1-4223-b087-6877b5ef7df0.png)

## Checklist:

- [x] Code Quality
- [x] Pep-8
- [x] Tests (if applicable)
- [x] Success Criteria Met
- [x] Inline Documentation
- [ ] Wiki Documentation (if applicable)
