### PR TITLE
Add option to provide time frame to `/until` command

### DIFF
--- a/buttercup/cogs/helpers.py
+++ b/buttercup/cogs/helpers.py
@@ -247,6 +247,23 @@ def get_user_id(user: Optional[BlossomUser]) -> Optional[int]:
     return user["id"] if user else None
 
 
+def get_user_gamma(user: Optional[BlossomUser], blossom_api: BlossomAPI) -> int:
+    """Get the gamma of the given user.
+
+    If it is None, it will get the total gamma of everyone.
+    This makes a server request, so the result should be reused.
+    """
+    if user:
+        return user["gamma"]
+
+    gamma_response = blossom_api.get(
+        "submission/", params={"page_size": 1, "completed_by__isnull": False},
+    )
+    if not gamma_response.ok:
+        raise BlossomException(gamma_response)
+    return gamma_response.json()["count"]
+
+
 def extract_sub_name(subreddit: str) -> str:
     """Extract the name of the sub without prefix."""
     if subreddit.startswith("/r/"):

--- a/buttercup/cogs/history.py
+++ b/buttercup/cogs/history.py
@@ -208,11 +208,13 @@ def parse_goal_str(goal_str: str) -> Tuple[int, str]:
     goal_str = goal_str.strip()
 
     if goal_str.isnumeric():
-        return int(goal_str, 10), goal_str
+        goal_gamma = int(goal_str, 10)
+        return goal_gamma, f"{goal_gamma:,}"
 
     for rank in ranks:
         if goal_str.casefold() == rank["name"].casefold():
-            return rank["threshold"], f"{rank['name']} ({rank['threshold']})"
+            goal_gamma = int(rank['threshold'])
+            return rank["threshold"], f"{rank['name']} ({goal_gamma:,})"
 
     raise InvalidArgumentException("goal", goal_str)
 
@@ -745,10 +747,7 @@ class History(Cog):
         elif user:
             # Take the next rank for the user
             next_rank = get_next_rank(user["gamma"])
-            goal_gamma, goal_str = (
-                next_rank["threshold"],
-                f"{next_rank['name']} ({next_rank['threshold']})",
-            )
+            goal_gamma, goal_str = parse_goal_str(next_rank["name"])
         else:
             # You can't get the "next rank" of the whole server
             raise InvalidArgumentException("goal", "<empty>")

--- a/buttercup/cogs/history.py
+++ b/buttercup/cogs/history.py
@@ -35,7 +35,7 @@ from buttercup.cogs.helpers import (
     get_username,
     get_usernames,
     parse_time_constraints,
-    get_user_gamma,
+    get_user_gamma, get_discord_time_str,
 )
 from buttercup.strings import translation
 
@@ -664,11 +664,12 @@ class History(Cog):
             seconds_needed = (target["gamma"] - user["gamma"]) / (
                 (user_progress - target_progress) / time_frame.total_seconds()
             )
-            time_needed = timedelta(seconds=seconds_needed)
+            relative_time = timedelta(seconds=seconds_needed)
+            absolute_time = start + relative_time
 
             intersection_gamma = user["gamma"] + math.ceil(
                 (user_progress / time_frame.total_seconds())
-                * time_needed.total_seconds()
+                * relative_time.total_seconds()
             )
 
             description = i18n["until"]["embed_description_user_prediction"].format(
@@ -680,7 +681,8 @@ class History(Cog):
                 target_progress=target_progress,
                 intersection_gamma=intersection_gamma,
                 time_frame=get_timedelta_str(time_frame),
-                time_needed=get_timedelta_str(time_needed),
+                relative_time=get_timedelta_str(relative_time),
+                absolute_time=get_discord_time_str(absolute_time),
             )
 
         color = get_rank(target["gamma"])["color"]
@@ -806,9 +808,10 @@ class History(Cog):
         else:
             # Based on the progress in the timeframe, calculate the time needed
             gamma_needed = goal_gamma - user_gamma
-            time_needed = timedelta(
+            relative_time = timedelta(
                 seconds=gamma_needed * (time_frame.total_seconds() / user_progress)
             )
+            absolute_time = start + relative_time
 
             description = i18n["until"]["embed_description_prediction"].format(
                 time_frame="week",
@@ -816,7 +819,8 @@ class History(Cog):
                 user_gamma=user_gamma,
                 goal=goal_str,
                 user_progress=user_progress,
-                time_needed=get_timedelta_str(time_needed),
+                relative_time=get_timedelta_str(relative_time),
+                absolute_time=get_discord_time_str(absolute_time),
             )
 
         # Determine the color of the target rank

--- a/buttercup/cogs/history.py
+++ b/buttercup/cogs/history.py
@@ -11,7 +11,7 @@ from blossom_wrapper import BlossomAPI, BlossomStatus
 from dateutil import parser
 from dateutil.tz import tzutc
 from discord import Embed, File
-from discord.ext.commands import Cog
+from discord.ext.commands import Cog, UserNotFound
 from discord_slash import SlashContext, cog_ext
 from discord_slash.model import SlashMessage
 from discord_slash.utils.manage_commands import create_option
@@ -35,6 +35,7 @@ from buttercup.cogs.helpers import (
     get_username,
     get_usernames,
     parse_time_constraints,
+    get_user_gamma,
 )
 from buttercup.strings import translation
 
@@ -283,16 +284,7 @@ class History(Cog):
         Note: We always need to do this, because it might be the case that some
         transcriptions don't have a date set.
         """
-        if user:
-            gamma = user["gamma"]
-        else:
-            # We need to get the total gamma of all users
-            gamma_response = self.blossom_api.get(
-                "submission/", params={"page_size": 1, "completed_by__isnull": False},
-            )
-            if not gamma_response.ok:
-                raise BlossomException(gamma_response)
-            gamma = gamma_response.json()["count"]
+        gamma = get_user_gamma(user, self.blossom_api)
 
         if before_time is not None:
             # We need to get the offset from the API
@@ -605,36 +597,45 @@ class History(Cog):
         )
 
     async def _get_user_progress(
-        self, user: Dict[str, Any], start: datetime, time_frame: timedelta
+        self, user: Optional[BlossomUser], start: datetime, time_frame: timedelta
     ) -> int:
         # We ask for submission completed by the user in the time frame
         # The response will contain a count, so we just need 1 result
         progress_response = self.blossom_api.get(
             "submission/",
             params={
-                "completed_by": user["id"],
+                "completed_by": get_user_id(user),
                 "from": (start - time_frame).isoformat(),
                 "page_size": 1,
             },
         )
         if progress_response.status_code != 200:
-            raise RuntimeError("Failed to get progress")
+            raise BlossomException(progress_response)
+
         return progress_response.json()["count"]
 
     async def _until_user_catch_up(
         self,
+        ctx: SlashContext,
         msg: SlashMessage,
-        user: Dict[str, Any],
+        user: BlossomUser,
         target_username: str,
         start: datetime,
     ) -> None:
         """Determine how long it will take the user to catch up with the target user."""
         # Try to find the target user
-        target_response = self.blossom_api.get_user(target_username)
-        if target_response.status != BlossomStatus.ok:
+        try:
+            target = get_user(target_username, ctx, self.blossom_api)
+        except UserNotFound:
+            # This doesn't mean the username is wrong
+            # They could have also mistyped a rank
+            # So we change the error message to something else
             raise InvalidArgumentException("goal", target_username)
 
-        target = target_response.data
+        if not target:
+            # Having the combined server as target doesn't make sense
+            # Because it includes the current user, they could never reach it
+            raise InvalidArgumentException("goal", target_username)
 
         if user["gamma"] > target["gamma"]:
             # Swap user and target, the target has to have more gamma
@@ -643,21 +644,15 @@ class History(Cog):
 
         time_frame = timedelta(weeks=1)
 
-        try:
-            user_progress = await self._get_user_progress(user, start, time_frame)
-            target_progress = await self._get_user_progress(target, start, time_frame)
-        except RuntimeError:
-            await msg.edit(
-                content=i18n["until"]["failed_getting_prediction"].format(user=user)
-            )
-            return
+        user_progress = await self._get_user_progress(user, start, time_frame)
+        target_progress = await self._get_user_progress(target, start, time_frame)
 
         if user_progress <= target_progress:
             description = i18n["until"]["embed_description_user_never"].format(
-                user=user["username"],
+                user=get_username(user),
                 user_gamma=user["gamma"],
                 user_progress=user_progress,
-                target=target["username"],
+                target=get_username(target),
                 target_gamma=target["gamma"],
                 target_progress=target_progress,
                 time_frame="week",
@@ -675,10 +670,10 @@ class History(Cog):
             )
 
             description = i18n["until"]["embed_description_user_prediction"].format(
-                user=user["username"],
+                user=get_username(user),
                 user_gamma=user["gamma"],
                 user_progress=user_progress,
-                target=target["username"],
+                target=get_username(target),
                 target_gamma=target["gamma"],
                 target_progress=target_progress,
                 intersection_gamma=intersection_gamma,
@@ -737,16 +732,28 @@ class History(Cog):
 
         if goal is not None:
             try:
+                # Check if the goal is a gamma value or rank name
                 goal_gamma, goal_str = parse_goal_str(goal)
             except InvalidArgumentException:
-                return await self._until_user_catch_up(msg, user, goal, start)
-        else:
+                # The goal could be a username
+                if not user:
+                    # If the user is the combined server, a target user doesn't make sense
+                    raise InvalidArgumentException("goal", goal)
+
+                # Try to treat the goal as a user
+                return await self._until_user_catch_up(ctx, msg, user, goal, start)
+        elif user:
             # Take the next rank for the user
             next_rank = get_next_rank(user["gamma"])
             goal_gamma, goal_str = (
                 next_rank["threshold"],
                 f"{next_rank['name']} ({next_rank['threshold']})",
             )
+        else:
+            # You can't get the "next rank" of the whole server
+            raise InvalidArgumentException("goal", "<empty>")
+
+        user_gamma = get_user_gamma(user, self.blossom_api)
 
         await msg.edit(
             content=i18n["until"]["getting_prediction_to_goal"].format(
@@ -754,7 +761,7 @@ class History(Cog):
             )
         )
 
-        if user["gamma"] == 0:
+        if user_gamma == 0:
             # The user has not started transcribing yet
             await msg.edit(
                 content=i18n["until"]["embed_message"].format(
@@ -781,12 +788,12 @@ class History(Cog):
             )
             return
 
-        if user["gamma"] >= goal_gamma:
+        if user_gamma >= goal_gamma:
             # The user has already reached the goal
             description = i18n["until"]["embed_description_reached"].format(
                 time_frame="week",
                 user=get_username(user),
-                user_gamma=user["gamma"],
+                user_gamma=user_gamma,
                 goal=goal_str,
                 user_progress=user_progress,
             )
@@ -794,12 +801,12 @@ class History(Cog):
             description = i18n["until"]["embed_description_zero"].format(
                 time_frame=get_timedelta_str(time_frame),
                 user=get_username(user),
-                user_gamma=user["gamma"],
+                user_gamma=user_gamma,
                 goal=goal_str,
             )
         else:
             # Based on the progress in the timeframe, calculate the time needed
-            gamma_needed = goal_gamma - user["gamma"]
+            gamma_needed = goal_gamma - user_gamma
             time_needed = timedelta(
                 seconds=gamma_needed * (time_frame.total_seconds() / user_progress)
             )
@@ -807,7 +814,7 @@ class History(Cog):
             description = i18n["until"]["embed_description_prediction"].format(
                 time_frame="week",
                 user=get_username(user),
-                user_gamma=user["gamma"],
+                user_gamma=user_gamma,
                 goal=goal_str,
                 user_progress=user_progress,
                 time_needed=get_timedelta_str(time_needed),

--- a/buttercup/strings/en_US.yaml
+++ b/buttercup/strings/en_US.yaml
@@ -182,7 +182,7 @@ until:
   getting_prediction: |
     Getting prediction for {user}...
   getting_prediction_to_goal: |
-    Getting prediction for {user} to reach {goal}...
+    Getting prediction for {user} to reach **{goal}**...
   user_not_found: |
     I couldn't find user {user}!
   embed_message: |
@@ -190,21 +190,21 @@ until:
   embed_title: |
     Prediction for {user}
   embed_description_prediction: |
-    **{user}** ({user_gamma}, {user_progress}/{time_frame}) will reach **{goal}** in {time_needed}!
+    **{user}** ({user_gamma:,} at {user_progress:,}/{time_frame}) will reach **{goal}** in {relative_time} ({absolute_time})!
   embed_description_reached: |
-    **{user}** ({user_gamma}, {user_progress}/{time_frame}) has already reached **{goal}**!
+    **{user}** ({user_gamma:,} at {user_progress:,}/{time_frame}) has already reached **{goal}**!
   embed_description_zero: |
-    **{user}** will **never** get from {user_gamma} to **{goal}** at this pace, they haven't transcribed anything in the past {time_frame}!
+    **{user}** will **never** get from {user_gamma:,} to **{goal}** at this pace, they haven't transcribed anything in the past {time_frame}!
   embed_description_new: |
     Hey {user}!
     It looks like you haven't started transribing yet. Do you need any help to get started?
     Feel free to ask any questions here or [send us a mod mail](https://www.reddit.com/message/compose?to=/r/TranscribersOfReddit).
   embed_description_user_prediction: |
-    **{user}** ({user_gamma}, {user_progress}/{time_frame}) will catch up with
-    **{target}** ({target_gamma}, {target_progress}/{time_frame}) in {time_needed} at {intersection_gamma} gamma!
+    **{user}** ({user_gamma:,}, {user_progress:,}/{time_frame}) will catch up with
+    **{target}** ({target_gamma:,}, {target_progress:,}/{time_frame}) in {relative_time} ({absolute_time}) at {intersection_gamma:,} gamma!
   embed_description_user_never: |
-    **{user}** ({user_gamma}, {user_progress}/{time_frame}) will never catch up with
-    **{target}** ({target_gamma}, {target_progress}/{time_frame}) at this pace!
+    **{user}** ({user_gamma:,}, {user_progress:,}/{time_frame}) will never catch up with
+    **{target}** ({target_gamma:,} at {target_progress:,}/{time_frame}) at this pace!
 partner:
   getting_partner_list: |
     Getting the list of our partners...

--- a/buttercup/strings/en_US.yaml
+++ b/buttercup/strings/en_US.yaml
@@ -180,33 +180,33 @@ pi_rules:
     PI Rules for r/{0}
 until:
   getting_prediction: |
-    Getting prediction for u/{user}...
+    Getting prediction for {user}...
   getting_prediction_to_goal: |
-    Getting prediction for u/{user} to reach {goal_gamma}...
+    Getting prediction for {user} to reach {goal}...
   user_not_found: |
-    I couldn't find user u/{user}!
+    I couldn't find user {user}!
   failed_getting_prediction: |
-    I couldn't get the prediction of u/{user}!
+    I couldn't get the prediction of {user}!
   embed_message: |
     Here is the prediction! ({duration})
   embed_title: |
-    Prediction for u/{user}
+    Prediction for {user}
   embed_description_prediction: |
-    **u/{user}** ({user_gamma}, {user_progress}/{time_frame}) will reach **{goal}** in {time_needed}!
+    **{user}** ({user_gamma}, {user_progress}/{time_frame}) will reach **{goal}** in {time_needed}!
   embed_description_reached: |
-    **u/{user}** ({user_gamma}, {user_progress}/{time_frame}) has already reached **{goal}**!
+    **{user}** ({user_gamma}, {user_progress}/{time_frame}) has already reached **{goal}**!
   embed_description_zero: |
-    **u/{user}** will **never** get from {user_gamma} to **{goal}** at this pace, they haven't transcribed anything in the past {time_frame}!
+    **{user}** will **never** get from {user_gamma} to **{goal}** at this pace, they haven't transcribed anything in the past {time_frame}!
   embed_description_new: |
-    Hey u/{user}!
+    Hey {user}!
     It looks like you haven't started transribing yet. Do you need any help to get started?
     Feel free to ask any questions here or [send us a mod mail](https://www.reddit.com/message/compose?to=/r/TranscribersOfReddit).
   embed_description_user_prediction: |
-    **u/{user}** ({user_gamma}, {user_progress}/{time_frame}) will catch up with
-    **u/{target}** ({target_gamma}, {target_progress}/{time_frame}) in {time_needed} at {intersection_gamma} gamma!
+    **{user}** ({user_gamma}, {user_progress}/{time_frame}) will catch up with
+    **{target}** ({target_gamma}, {target_progress}/{time_frame}) in {time_needed} at {intersection_gamma} gamma!
   embed_description_user_never: |
-    **u/{user}** ({user_gamma}, {user_progress}/{time_frame}) will never catch up with
-    **u/{target}** ({target_gamma}, {target_progress}/{time_frame}) at this pace!
+    **{user}** ({user_gamma}, {user_progress}/{time_frame}) will never catch up with
+    **{target}** ({target_gamma}, {target_progress}/{time_frame}) at this pace!
 partner:
   getting_partner_list: |
     Getting the list of our partners...

--- a/buttercup/strings/en_US.yaml
+++ b/buttercup/strings/en_US.yaml
@@ -185,8 +185,6 @@ until:
     Getting prediction for {user} to reach {goal}...
   user_not_found: |
     I couldn't find user {user}!
-  failed_getting_prediction: |
-    I couldn't get the prediction of {user}!
   embed_message: |
     Here is the prediction! ({duration})
   embed_title: |

--- a/buttercup/strings/en_US.yaml
+++ b/buttercup/strings/en_US.yaml
@@ -180,13 +180,13 @@ pi_rules:
     PI Rules for r/{0}
 until:
   getting_prediction: |
-    Getting prediction for {user}...
+    Getting prediction for {user}, using data {time_str}...
   getting_prediction_to_goal: |
-    Getting prediction for {user} to reach **{goal}**...
+    Getting prediction for {user} to reach **{goal}**, using data {time_str}...
   user_not_found: |
     I couldn't find user {user}!
   embed_message: |
-    Here is the prediction! ({duration})
+    Here is the prediction for {user} to reach **{goal}**, using data {time_str}! ({duration})
   embed_title: |
     Prediction for {user}
   embed_description_prediction: |


### PR DESCRIPTION
Relevant issue: Closes #93

## Description:

This adds the option to define the time frame that is used to calculate the predictions for the `/until` command.

It also adds a bunch of smaller features:
- You can make predictions for the whole server using keywords like `all`.
- Added thousand separators for all gamma values.
- Added absolute time of the prediction (localized via Discord).

## Screenshots:

![Prediction when everyone combined will reach 300,000 gamma, using data from the past 24 hours.](https://user-images.githubusercontent.com/13908946/146095341-1e277246-5dcb-46ea-bdd8-c589c354a56b.png)

## Checklist:

- [x] Code Quality
- [x] Pep-8
- [x] Tests (if applicable)
- [x] Success Criteria Met
- [x] Inline Documentation
- [ ] Wiki Documentation (if applicable)
