### PR TITLE
Add timestamps to `/search` results

### DIFF
--- a/buttercup/cogs/search.py
+++ b/buttercup/cogs/search.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, List, Optional, TypedDict
 
 import pytz
 from blossom_wrapper import BlossomAPI, BlossomStatus
+from dateutil import parser
 from discord import Embed, Reaction, User
 from discord.ext import commands
 from discord.ext.commands import Cog
@@ -22,6 +23,7 @@ from buttercup.cogs.helpers import (
     get_duration_str,
     get_username,
     parse_time_constraints,
+    get_discord_time_str,
 )
 from buttercup.strings import translation
 
@@ -93,9 +95,14 @@ def create_result_description(result: Dict[str, Any], num: int, query: str) -> s
     # Determine meta info about the post/transcription
     tr_type = get_transcription_type(result)
     tr_source = get_transcription_source(result)
+    time = parser.parse(result["create_time"])
     description = (
         i18n["search"]["description"]["item"].format(
-            num=num, tr_type=tr_type, tr_source=tr_source, url=result["url"],
+            num=num,
+            tr_type=tr_type,
+            tr_source=tr_source,
+            url=result["url"],
+            timestamp=get_discord_time_str(time, "R"),
         )
         # Start code block for occurrences
         + "\n```\n"

--- a/buttercup/strings/en_US.yaml
+++ b/buttercup/strings/en_US.yaml
@@ -267,7 +267,7 @@ search:
     No results found for `{query}` by {user} {time_str}. ({duration_str})
   description:
     item: |-
-      {num}. [{tr_type} on {tr_source}]({url})
+      {num}. [{tr_type} on {tr_source}]({url}) {timestamp}
     more_occurrences: |-
       ... and {count} more occurrence(s).
   embed_message: |-


### PR DESCRIPTION
Relevant issue: Closes #119

## Description:

This adds localized, relative timestamps to the results of the `/search` command. 
This should make it easier to identify the exact post that you are looking for.

Additionally, the way that the query occurrences are displayed has been improved.
It now shows as much "context" to the occurrence as possible on both sides, while still fitting in a single line (on a Desktop embed).
Before, it would sometimes wrap into the next line if the query string was long, or the result was truncated when there was still room left.

## Screenshots:

![The updated result of the `/search` command. It now displays relative timestamps, such as "3 months ago" for each result. It also shows more context to the query occurrences while still keeping them in a single line.](https://user-images.githubusercontent.com/13908946/146545642-4d1082de-f900-4f3f-bd9f-e0063bc0b48d.png)

## Checklist:

- [x] Code Quality
- [x] Pep-8
- [x] Tests (if applicable)
- [x] Success Criteria Met
- [x] Inline Documentation
- [ ] Wiki Documentation (if applicable)
