### PR TITLE
Replace submission time filters with new version

### DIFF
--- a/buttercup/cogs/heatmap.py
+++ b/buttercup/cogs/heatmap.py
@@ -139,8 +139,8 @@ class Heatmap(Cog):
             "submission/heatmap/",
             params={
                 "completed_by": get_user_id(user),
-                "from": from_str,
-                "until": until_str,
+                "complete_time__gte": from_str,
+                "complete_time__lte": until_str,
             },
         )
         if heatmap_response.status_code != 200:

--- a/buttercup/cogs/history.py
+++ b/buttercup/cogs/history.py
@@ -235,8 +235,8 @@ async def _get_user_progress(
         "submission/",
         params={
             "completed_by": get_user_id(user),
-            "from": from_str,
-            "until": until_str,
+            "complete_time__gte": from_str,
+            "complete_time__lte": until_str,
             "page_size": 1,
         },
     )
@@ -327,8 +327,8 @@ class History(Cog):
                     "page": page,
                     "page_size": page_size,
                     "time_frame": time_frame,
-                    "from": from_str,
-                    "until": until_str,
+                    "complete_time__gte": from_str,
+                    "complete_time__lte": until_str,
                 },
             )
             if response.status_code != 200:
@@ -371,7 +371,7 @@ class History(Cog):
                 params={
                     "completed_by__isnull": False,
                     "completed_by": get_user_id(user),
-                    "from": before_time.isoformat(),
+                    "complete_time__gte": before_time.isoformat(),
                     "page_size": 1,
                 },
             )

--- a/buttercup/cogs/history.py
+++ b/buttercup/cogs/history.py
@@ -563,6 +563,18 @@ class History(Cog):
                 option_type=3,
                 required=False,
             ),
+            create_option(
+                name="after",
+                description="The start date for the rate data.",
+                option_type=3,
+                required=False,
+            ),
+            create_option(
+                name="before",
+                description="The end date for the rate data.",
+                option_type=3,
+                required=False,
+            ),
         ],
     )
     async def _rate(
@@ -774,13 +786,13 @@ class History(Cog):
             ),
             create_option(
                 name="after",
-                description="The start date for the rate data.",
+                description="The start date for the prediction data.",
                 option_type=3,
                 required=False,
             ),
             create_option(
                 name="before",
-                description="The end date for the rate data.",
+                description="The end date for the prediction data.",
                 option_type=3,
                 required=False,
             ),

--- a/buttercup/cogs/leaderboard.py
+++ b/buttercup/cogs/leaderboard.py
@@ -114,8 +114,8 @@ class Leaderboard(Cog):
                 "top_count": top_count,
                 "below_count": context_count,
                 "above_count": context_count,
-                "from": from_str,
-                "until": until_str,
+                "complete_time__gte": from_str,
+                "complete_time__lte": until_str,
             },
         )
         if leaderboard_response.status_code != 200:

--- a/buttercup/cogs/stats.py
+++ b/buttercup/cogs/stats.py
@@ -241,8 +241,8 @@ class Stats(Cog):
             "submission/",
             params={
                 "completed_by": get_user_id(user),
-                "from": from_str,
-                "until": until_str,
+                "complete_time__gte": from_str,
+                "complete_time__lte": until_str,
                 "page_size": 1,
             },
         )


### PR DESCRIPTION
Relevant issue: GrafeasGroup/blossom#228

## Description:

This replaces the 'from' query parameter with 'complete_time__gte' as well as 'until' with 'complete_time__lte'.

Directly depends on GrafeasGroup/blossom#228, which needs to be merged and deployed first.
While the new system is deployed and this PR not merged, most Buttercup commands won't work with time filters.

**Note:** This needs to be tested with the new deployed time filters before merging!

## Testing Instructions:

All commands need to be tested with time filters. It needs to be ensured that the commands don't throw any new errors and that the correct time frames are filtered.
This should be tested with both absolute and relative commands.

## Checklist:

- [x] Code Quality
- [x] Pep-8
- [ ] Tests (if applicable)
- [x] Success Criteria Met
- [ ] Inline Documentation
- [ ] Wiki Documentation (if applicable)
