### PR TITLE
Improve `/rate` and `/history` color selection

### DIFF
--- a/buttercup/cogs/history.py
+++ b/buttercup/cogs/history.py
@@ -168,7 +168,9 @@ def get_user_colors(users: Optional[List[BlossomUser]]) -> List[str]:
         # Give the user their rank color if possible
         if user_rank in available_ranks:
             color_mapping[user["username"]] = user_rank["color"]
-            available_ranks = [r for r in available_ranks if r["name"] != user_rank["name"]]
+            available_ranks = [
+                r for r in available_ranks if r["name"] != user_rank["name"]
+            ]
         else:
             left_over_users.append(user)
 

--- a/buttercup/cogs/history.py
+++ b/buttercup/cogs/history.py
@@ -148,6 +148,37 @@ def add_zero_rates(
     return data.reindex(new_index, fill_value=0).sort_index()
 
 
+def get_user_colors(users: Optional[List[BlossomUser]]) -> List[str]:
+    """Assign a color to each user.
+
+    This will prefer to assign a user their rank color.
+    A single user will get white for better readability.
+    """
+    if not users or len(users) == 1:
+        # If we don't need to distinguish, take white (best contrast)
+        return ["#eeeeee"]
+
+    color_mapping = {}
+    available_ranks = [r for r in ranks]
+    left_over_users = []
+
+    for user in users:
+        user_rank = get_rank(user["gamma"])
+
+        # Give the user their rank color if possible
+        if user_rank in available_ranks:
+            color_mapping[user["username"]] = user_rank["color"]
+            available_ranks = [r for r in available_ranks if r["name"] != user_rank["name"]]
+        else:
+            left_over_users.append(user)
+
+    # Give the left over users another rank's color
+    for i, user in enumerate(left_over_users):
+        color_mapping[user["username"]] = available_ranks[i]["color"]
+
+    return [color_mapping[user["username"]] for user in users]
+
+
 def add_milestone_lines(
     ax: plt.Axes,
     milestones: List[Dict[str, Union[str, int]]],

--- a/buttercup/cogs/history.py
+++ b/buttercup/cogs/history.py
@@ -485,6 +485,7 @@ class History(Cog):
         )
 
         users = get_user_list(usernames, ctx, self.blossom_api)
+        colors = get_user_colors(users)
 
         min_gammas = []
         max_gammas = []
@@ -519,7 +520,7 @@ class History(Cog):
 
             history_data = self.get_user_history(user, after_time, before_time)
 
-            color = ranks[index]["color"]
+            color = colors[index]
             first_point = history_data.iloc[0]
             last_point = history_data.iloc[-1]
 
@@ -617,6 +618,7 @@ class History(Cog):
         )
 
         users = get_user_list(usernames, ctx, self.blossom_api)
+        colors = get_user_colors(users)
 
         max_rates = []
 
@@ -654,7 +656,7 @@ class History(Cog):
             max_rates.append(max_rate)
             max_rate_point = user_data[user_data["count"] == max_rate].iloc[0]
 
-            color = ranks[index]["color"]
+            color = colors[index]
 
             # Plot the graph
             ax.plot(

--- a/buttercup/cogs/history.py
+++ b/buttercup/cogs/history.py
@@ -485,6 +485,7 @@ class History(Cog):
         )
 
         users = get_user_list(usernames, ctx, self.blossom_api)
+        users.sort(key=lambda u: u["gamma"], reverse=True)
         colors = get_user_colors(users)
 
         min_gammas = []
@@ -618,6 +619,7 @@ class History(Cog):
         )
 
         users = get_user_list(usernames, ctx, self.blossom_api)
+        users.sort(key=lambda u: u["gamma"], reverse=True)
         colors = get_user_colors(users)
 
         max_rates = []


### PR DESCRIPTION
Relevant issue: Closes #79

## Description:

This improves the color selection for the graph lines of `/rate` and `/history`. It will now prefer a user's rank color, making it easier to recognize each user at a glance.

Users are now also sorted by their gamma for the graph commands.

## Screenshots:

![The `/history` command for 4 users. Each user is assigned their rank's color, making the graph more readable.](https://user-images.githubusercontent.com/13908946/146649527-77af814b-af19-4419-8527-0325ca584731.png)

## Checklist:

- [x] Code Quality
- [x] Pep-8
- [ ] Tests (if applicable)
- [x] Success Criteria Met
- [x] Inline Documentation
- [ ] Wiki Documentation (if applicable)
