### PR TITLE
Rework search command with new username helper functions

### DIFF
--- a/buttercup/strings/en_US.yaml
+++ b/buttercup/strings/en_US.yaml
@@ -262,7 +262,7 @@ leaderboard:
     Leaderboard for {user} ({time_frame})
 search:
   getting_search: |-
-    Searching for `{query}` {time_str}...
+    Searching for `{query}` in transcriptions by {user} {time_str}...
   no_results: |-
     No results found for `{query}` by {user} {time_str}. ({duration_str})
   description:
@@ -271,7 +271,7 @@ search:
     more_occurrences: |-
       ... and {count} more occurrence(s).
   embed_message: |-
-    Here are your results for `{query}` by {user} {time_str}! ({duration_str})
+    Here are your results for `{query}` in transcriptions by {user} {time_str}! ({duration_str})
   embed_title: |-
     Results for `{query}` by {user}
   embed_footer: |-


### PR DESCRIPTION
Relevant issue: Closes #123

## Description:

The new username helper functions weren't applied everywhere in the search command, resulting in the 'me' keyword not working correctly.

## Checklist:

- [x] Code Quality
- [x] Pep-8
- [ ] Tests (if applicable)
- [x] Success Criteria Met
- [x] Inline Documentation
- [ ] Wiki Documentation (if applicable)
