### PR TITLE
Fix username placeholders in `/progress` command

### DIFF
--- a/buttercup/strings/en_US.yaml
+++ b/buttercup/strings/en_US.yaml
@@ -74,7 +74,7 @@ progress:
       - Taking a break?
       - Transcribing a post would be a good start.
       - At that pace we're gonna be here a long time.
-      - There are people who transcribe and there's u/{user}.
+      - There are people who transcribe and there's {user}.
       - Not sure what you expected. You know exactly how much it is.
       - Slow and stead wins the race. Too bad this is not a race.
       - At least there are more posts for the others.
@@ -84,7 +84,7 @@ progress:
       - A good start, keep on going!
       - Don't worry, you'll get there eventually!
       - It's a long road, but a rewarding one!
-      - '"After executing the `/progress` command, u/{user} claimed another post."'
+      - '"After executing the `/progress` command, {user} claimed another post."'
       - Oh! Do it again!
       - More. MORE!
     25:
@@ -109,25 +109,25 @@ progress:
     100:
       - "Done and dusted! Great job! :partying_face:"
       - "It's finally done! Congrats! :tada:"
-      - '"Challenge? What challenge?", u/{user} said.'
+      - '"Challenge? What challenge?", {user} said.'
       - The party will be at my place!
-      - Pop the champagne, u/{user} did it!
-      - I wish I could be as cool as u/{user}...
+      - Pop the champagne, {user} did it!
+      - I wish I could be as cool as {user}...
     105:
       - You're already finished. You can stop now.
       - It's addicting, isn't it?
     200:
-      - u/{user}. We'll remember that name for a long time.
+      - "{user}. We'll remember that name for a long time."
       - I thought I was the only bot here...
       - You can't split your 200/24 and give half of it to another user. Just thought I should clarify this.
-      - Sometimes I ask myself how many cats u/{user} trained to make transcriptions for them.
+      - Sometimes I ask myself how many cats {user} trained to make transcriptions for them.
     300:
       - Uhm. Please leave a few posts for the others...
     400:
       - Clearing the queue all by yourself?
       - I'm not a doctor, but I'm not sure how healthy this is...
     500:
-      - Well. It finally happened. And of course it's u/{user}.
+      - Well. It finally happened. And of course it's {user}.
       - Is that a 500/24 or is the progress bar just happy to see me?
 heatmap:
   getting_heatmap: |


### PR DESCRIPTION
Relevant issue: Closes #125

## Description:

Due to the changes of the way usernames are handled, the progress messages included a duplicate u/ prefix.
This issue has now been resolved by removing the prefix from the localization files.

## Checklist:

- [x] Code Quality
- [x] Pep-8
- [ ] Tests (if applicable)
- [x] Success Criteria Met
- [ ] Inline Documentation
- [ ] Wiki Documentation (if applicable)
