### PR TITLE
Add leaderboard rank to `/stats` command

### DIFF
--- a/buttercup/cogs/stats.py
+++ b/buttercup/cogs/stats.py
@@ -128,7 +128,7 @@ class Stats(Cog):
                 "page": 1,
             },
         )
-        if submission_response.status_code != 200:
+        if not submission_response.ok:
             raise BlossomException(submission_response)
 
         submission_data = submission_response.json()["results"][0]
@@ -246,13 +246,9 @@ class Stats(Cog):
                 "page_size": 1,
             },
         )
-        if progress_response.status_code != 200:
-            await msg.edit(
-                content=i18n["progress"]["failed_getting_progress"].format(
-                    user=get_username(user)
-                )
-            )
-            return
+        if not progress_response.ok:
+            raise BlossomException(progress_response)
+
         progress_count = progress_response.json()["count"]
 
         # The progress bar only makes sense for a 24 hour time frame

--- a/buttercup/cogs/stats.py
+++ b/buttercup/cogs/stats.py
@@ -141,11 +141,27 @@ class Stats(Cog):
             or submission_data["create_time"]
         )
 
+        # Get the user's leaderboard rank
+        leaderboard_response = self.blossom_api.get(
+            "submission/leaderboard",
+            params={
+                "user_id": get_user_id(user),
+                "top_count": 0,
+                "below_count": 0,
+                "above_count": 0,
+            },
+        )
+        if leaderboard_response.status_code != 200:
+            raise BlossomException(leaderboard_response)
+
+        leaderboard_rank = leaderboard_response.json()["user"]["rank"]
+
         rank = get_rank(user["gamma"])
 
         description = i18n["stats"]["embed_description_user"].format(
             gamma=user["gamma"],
             flair_rank=rank["name"],
+            leaderboard_rank=leaderboard_rank,
             date_joined=get_discord_time_str(date_joined),
             joined_ago=get_discord_time_str(date_joined, "R"),
             last_active=get_discord_time_str(last_active),

--- a/buttercup/strings/en_US.yaml
+++ b/buttercup/strings/en_US.yaml
@@ -52,8 +52,6 @@ stats:
 progress:
   getting_progress: |
     Getting progress of {user} {time_str}...
-  user_not_found: |
-    I couldn't find user {user}!
   embed_message: |
     Here is the progress of {user}! ({duration})
   embed_title: |

--- a/buttercup/strings/en_US.yaml
+++ b/buttercup/strings/en_US.yaml
@@ -46,6 +46,7 @@ stats:
     **Days Since Inception**: {days:,d}
   embed_description_user: |
     **Transcriptions**: {gamma:,d}
+    **Leaderboard Rank**: #{leaderboard_rank}
     **Flair Rank**: {flair_rank}
     **Date Joined**: {date_joined} ({joined_ago})
     **Last Active**: {last_active} ({last_ago})

--- a/buttercup/strings/en_US.yaml
+++ b/buttercup/strings/en_US.yaml
@@ -74,7 +74,7 @@ progress:
       - Taking a break?
       - Transcribing a post would be a good start.
       - At that pace we're gonna be here a long time.
-      - There are people who transcribe and there's u/{user}.
+      - There are people who transcribe and there's {user}.
       - Not sure what you expected. You know exactly how much it is.
       - Slow and stead wins the race. Too bad this is not a race.
       - At least there are more posts for the others.
@@ -84,7 +84,7 @@ progress:
       - A good start, keep on going!
       - Don't worry, you'll get there eventually!
       - It's a long road, but a rewarding one!
-      - '"After executing the `/progress` command, u/{user} claimed another post."'
+      - '"After executing the `/progress` command, {user} claimed another post."'
       - Oh! Do it again!
       - More. MORE!
     25:
@@ -109,25 +109,25 @@ progress:
     100:
       - "Done and dusted! Great job! :partying_face:"
       - "It's finally done! Congrats! :tada:"
-      - '"Challenge? What challenge?", u/{user} said.'
+      - '"Challenge? What challenge?", {user} said.'
       - The party will be at my place!
-      - Pop the champagne, u/{user} did it!
-      - I wish I could be as cool as u/{user}...
+      - Pop the champagne, {user} did it!
+      - I wish I could be as cool as {user}...
     105:
       - You're already finished. You can stop now.
       - It's addicting, isn't it?
     200:
-      - u/{user}. We'll remember that name for a long time.
+      - "{user}. We'll remember that name for a long time."
       - I thought I was the only bot here...
       - You can't split your 200/24 and give half of it to another user. Just thought I should clarify this.
-      - Sometimes I ask myself how many cats u/{user} trained to make transcriptions for them.
+      - Sometimes I ask myself how many cats {user} trained to make transcriptions for them.
     300:
       - Uhm. Please leave a few posts for the others...
     400:
       - Clearing the queue all by yourself?
       - I'm not a doctor, but I'm not sure how healthy this is...
     500:
-      - Well. It finally happened. And of course it's u/{user}.
+      - Well. It finally happened. And of course it's {user}.
       - Is that a 500/24 or is the progress bar just happy to see me?
 heatmap:
   getting_heatmap: |


### PR DESCRIPTION
Relevant issue: Closes #126

## Description:

This adds the current leaderboard rank of the user to the output of the `/stats` command.

## Screenshots:

![The response to the `/stats` command for u/Tim3303. It now includes a "Leaderboard Rank" entry, showing the current rank of the given user.](https://user-images.githubusercontent.com/13908946/146672416-031130d4-c208-4964-adf5-6713e69c3f51.png)

## Checklist:

- [x] Code Quality
- [x] Pep-8
- [ ] Tests (if applicable)
- [x] Success Criteria Met
- [x] Inline Documentation
- [ ] Wiki Documentation (if applicable)
