### PR TITLE
Fix /search command not working in DMs

### DIFF
--- a/buttercup/cogs/search.py
+++ b/buttercup/cogs/search.py
@@ -250,14 +250,15 @@ class Search(Cog):
     ) -> None:
         """Execute the search with the given cache."""
         # Clear previous control emojis
-        try:
-            await msg.clear_reactions()
-        except Forbidden:
-            # The bot is not allowed to clear reactions
-            # This can happen when the command is executed in a DM
-            # We need to clear the reactions manually
-            for emoji in msg.reactions:
-                await msg.remove_reaction(emoji, msg.author)
+        if len(msg.reactions) > 0:
+            try:
+                await msg.clear_reactions()
+            except Forbidden:
+                # The bot is not allowed to clear reactions
+                # This can happen when the command is executed in a DM
+                # We need to clear the reactions manually
+                for emoji in msg.reactions:
+                    await msg.remove_reaction(emoji, msg.author)
 
         discord_page = cache_item["cur_page"] + page_mod
         query = cache_item["query"]

--- a/buttercup/cogs/search.py
+++ b/buttercup/cogs/search.py
@@ -158,6 +158,19 @@ def create_result_description(result: Dict[str, Any], num: int, query: str) -> s
     return description
 
 
+async def clear_reactions(msg: SlashMessage) -> None:
+    """Clear previously set control emojis."""
+    if len(msg.reactions) > 0:
+        try:
+            await msg.clear_reactions()
+        except Forbidden:
+            # The bot is not allowed to clear reactions
+            # This can happen when the command is executed in a DM
+            # We need to clear the reactions manually
+            for emoji in msg.reactions:
+                await msg.remove_reaction(emoji, msg.author)
+
+
 class SearchCacheItem(TypedDict):
     # The query that the user searched for
     query: str
@@ -250,15 +263,7 @@ class Search(Cog):
     ) -> None:
         """Execute the search with the given cache."""
         # Clear previous control emojis
-        if len(msg.reactions) > 0:
-            try:
-                await msg.clear_reactions()
-            except Forbidden:
-                # The bot is not allowed to clear reactions
-                # This can happen when the command is executed in a DM
-                # We need to clear the reactions manually
-                for emoji in msg.reactions:
-                    await msg.remove_reaction(emoji, msg.author)
+        await clear_reactions(msg)
 
         discord_page = cache_item["cur_page"] + page_mod
         query = cache_item["query"]

--- a/buttercup/cogs/search.py
+++ b/buttercup/cogs/search.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, List, Optional, TypedDict
 import pytz
 from blossom_wrapper import BlossomAPI
 from dateutil import parser
-from discord import Embed, Reaction, User
+from discord import Embed, Forbidden, Reaction, User
 from discord.ext import commands
 from discord.ext.commands import Cog
 from discord_slash import SlashContext, cog_ext
@@ -250,7 +250,14 @@ class Search(Cog):
     ) -> None:
         """Execute the search with the given cache."""
         # Clear previous control emojis
-        await msg.clear_reactions()
+        try:
+            await msg.clear_reactions()
+        except Forbidden:
+            # The bot is not allowed to clear reactions
+            # This can happen when the command is executed in a DM
+            # We need to clear the reactions manually
+            for emoji in msg.reactions:
+                await msg.remove_reaction(emoji, msg.author)
 
         discord_page = cache_item["cur_page"] + page_mod
         query = cache_item["query"]


### PR DESCRIPTION
Relevant issue: Closes #131

## Description:

When used in a DM, the `/search` command failed with an error.
This is because the bot doesn't have permission to clear the reactions of a message in a DM.

Instead, the bot now falls back to removing its own reactions one by one.
This is less efficient and results in the controls not being ordered (because the option selected by the user gets stuck), but I think this is the only way to implement this.

## Checklist:

- [x] Code Quality
- [x] Pep-8
- [ ] Tests (if applicable)
- [x] Success Criteria Met
- [x] Inline Documentation
- [ ] Wiki Documentation (if applicable)
