### PR TITLE
Rework admin command permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,28 +19,23 @@ Apart from this, a `.toml` configuration file is expected. Below is a default `c
 ```
 [Discord]
 token = "<YOUR DISCORD BOT SECRET HERE>"
+# Used for admin command permissions
+guilds = [
+    { id = "<guild_id>", mod_roles = ["<role_id>"] },
+]
 
 [Reddit]
 client_id = "<YOUR REDDIT CLIENT ID HERE>"
 client_secret = "<YOUR REDDIT CLIENT SECRET HERE>"
 user_agent = "grafeas.org.buttercup:v0.1.0 (contact u/<YOUR USERNAME HERE>)"
 
-[guild]
-name = "Test Bubbles"
-
-[Admin]
-role = "ToR Mods"
-
-[NameValidator]
-accepted_role = "Visitor (0)"
-restrict_role = "New User"
-restrict_channel = "new-user"
-welcome_channel = "off-topic"
-
 [Blossom]
 email = ""
 password = ""
 api_key = ""
+
+[NameValidator]
+valid_role_id = "<role_id>"
 ```
 The `secrets` section contains all secrets required to run Buttercup:
 - `discord` is Discord's bot secret

--- a/buttercup/bot.py
+++ b/buttercup/bot.py
@@ -26,7 +26,6 @@ class ButtercupBot(Bot):
         self.slash = SlashCommand(self, sync_commands=True, sync_on_cog_reload=True)
         self.config_path = kwargs.get("config_path", "../config.toml")
         self.cog_path = kwargs.get("cog_path", "buttercup.cogs.")
-        self.guild_name = self.config["guild"]["name"]
 
         for extension in kwargs.get("extensions", list()):
             logging.info(f"Loading extension {extension}...")
@@ -34,17 +33,12 @@ class ButtercupBot(Bot):
 
     async def on_ready(self) -> None:
         """Log a starting message when the bot is ready."""
-        logging.info(f"Connected as {self.user} to '{self.guild}'")
+        logging.info(f"Connected as {self.user}")
 
     @property
     def config(self) -> Dict[str, Any]:
         """Provide the configuration loaded from the specified file."""
         return defaultdict(dict, toml.load(self.config_path))
-
-    @property
-    def guild(self) -> Guild:
-        """Retrieve the guild corresponding to the set name."""
-        return discord.utils.get(self.guilds, name=self.guild_name)
 
     def load(self, name: str) -> None:
         """Load the extension with the specified name."""

--- a/buttercup/bot.py
+++ b/buttercup/bot.py
@@ -5,7 +5,6 @@ from typing import Any, Dict
 import discord.utils
 import toml
 from discord.ext.commands import Bot
-from discord.guild import Guild
 from discord_slash import SlashCommand
 
 

--- a/buttercup/cogs/admin.py
+++ b/buttercup/cogs/admin.py
@@ -1,5 +1,6 @@
-from discord import Member
-from discord.ext.commands import CheckFailure, Cog
+from typing import Dict
+
+from discord.ext.commands import Cog
 from discord_slash import SlashContext, cog_ext
 from discord_slash.model import SlashCommandPermissionType
 from discord_slash.utils.manage_commands import create_option, create_permission
@@ -8,7 +9,7 @@ from buttercup.bot import ButtercupBot
 from buttercup.cogs.config import config
 
 
-def generate_admin_permissions():
+def generate_admin_permissions() -> Dict:
     """Generate the admin permissions from the config.
 
     Note that this is a bit hacky and the config cog has to be loaded first.

--- a/buttercup/cogs/admin.py
+++ b/buttercup/cogs/admin.py
@@ -1,20 +1,34 @@
 from discord import Member
 from discord.ext.commands import CheckFailure, Cog
 from discord_slash import SlashContext, cog_ext
-from discord_slash.utils.manage_commands import create_option
+from discord_slash.model import SlashCommandPermissionType
+from discord_slash.utils.manage_commands import create_option, create_permission
 
 from buttercup.bot import ButtercupBot
+from buttercup.cogs.config import config
+
+
+def generate_admin_permissions():
+    """Generate the admin permissions from the config.
+
+    Note that this is a bit hacky and the config cog has to be loaded first.
+    Unfortunately we can't use the bot object in the annotation, so we can't
+    access the config like this directly.
+    """
+    permissions = {}
+    for guild in config["Discord"]["guilds"]:
+        permissions[guild["id"]] = [
+            create_permission(role_id, SlashCommandPermissionType.ROLE, True)
+            for role_id in guild["mod_roles"]
+        ]
+    print(permissions)
+    return permissions
 
 
 class AdminCommands(Cog):
-    def __init__(self, bot: ButtercupBot, role_name: str = "ToR Mods") -> None:
+    def __init__(self, bot: ButtercupBot) -> None:
         """Initialize the Admin Commands cog."""
         self.bot = bot
-        self.role_name = role_name
-
-    def _is_authorized(self, member: Member) -> bool:
-        """Check whether the user invoking the command is the correct role."""
-        return self.role_name in {role.name for role in member.roles}
 
     @cog_ext.cog_slash(
         name="reload",
@@ -27,11 +41,11 @@ class AdminCommands(Cog):
                 required=True,
             )
         ],
+        default_permission=False,
+        permissions=generate_admin_permissions(),
     )
     async def _reload(self, ctx: SlashContext, cog_name: str) -> None:
         """Allow for the provided cog to be reloaded."""
-        if not self._is_authorized(ctx.author):
-            raise CheckFailure()
         self.bot.reload(cog_name)
         await ctx.send(f'Cog "{cog_name}" has been successfully reloaded :+1:')
 
@@ -46,11 +60,11 @@ class AdminCommands(Cog):
                 required=True,
             )
         ],
+        default_permission=False,
+        permissions=generate_admin_permissions(),
     )
     async def _load(self, ctx: SlashContext, cog_name: str) -> None:
         """Allow for the provided cog to be loaded."""
-        if not self._is_authorized(ctx.author):
-            raise CheckFailure()
         self.bot.load(cog_name)
         await ctx.send(f'Cog "{cog_name}" has been successfully loaded :+1:')
 
@@ -65,19 +79,18 @@ class AdminCommands(Cog):
                 required=True,
             )
         ],
+        default_permission=False,
+        permissions=generate_admin_permissions(),
     )
     async def _unload(self, ctx: SlashContext, cog_name: str) -> None:
         """Allow for the provided cog to be unloaded."""
-        if not self._is_authorized(ctx.author):
-            raise CheckFailure()
         self.bot.unload(cog_name)
         await ctx.send(f'Cog "{cog_name}" has been successfully unloaded :+1:')
 
 
 def setup(bot: ButtercupBot) -> None:
     """Set up the Admin cog."""
-    role_name = bot.config["Admin"]["role"]
-    bot.add_cog(AdminCommands(bot, role_name))
+    bot.add_cog(AdminCommands(bot))
 
 
 def teardown(bot: ButtercupBot) -> None:

--- a/buttercup/cogs/config.py
+++ b/buttercup/cogs/config.py
@@ -1,0 +1,20 @@
+from typing import Dict, Any
+
+from buttercup.bot import ButtercupBot
+
+
+config = Dict[str, Any]
+
+
+def setup(bot: ButtercupBot) -> None:
+    """Set up the config globally.
+
+    This is a hack to be able to use it in annotations for other commands.
+    This cog needs to be loaded first for it to work correctly!
+    """
+    global config
+    config = bot.config
+
+
+def teardown(bot: ButtercupBot) -> None:
+    pass

--- a/buttercup/cogs/config.py
+++ b/buttercup/cogs/config.py
@@ -1,9 +1,8 @@
-from typing import Dict, Any
+from typing import Any, Dict
 
 from buttercup.bot import ButtercupBot
 
-
-config = Dict[str, Any]
+config: Dict[str, Any] = {}
 
 
 def setup(bot: ButtercupBot) -> None:
@@ -17,4 +16,6 @@ def setup(bot: ButtercupBot) -> None:
 
 
 def teardown(bot: ButtercupBot) -> None:
-    pass
+    """Reset the global config."""
+    global config
+    config = {}

--- a/buttercup/cogs/handlers.py
+++ b/buttercup/cogs/handlers.py
@@ -38,10 +38,7 @@ class Handlers(commands.Cog):
             traceback.format_exception(type(error), error, error.__traceback__)
         )
 
-        if isinstance(error, commands.CheckFailure):
-            logger.warning("An unauthorized Command was performed.", ctx)
-            await ctx.send(i18n["handlers"]["not_authorized"])
-        elif isinstance(error, NoUsernameException):
+        if isinstance(error, NoUsernameException):
             logger.warning("Command executed without providing a username.", ctx)
             await ctx.send(i18n["handlers"]["no_username"])
         elif isinstance(error, UserNotFoundException):

--- a/buttercup/main.py
+++ b/buttercup/main.py
@@ -4,6 +4,8 @@ from buttercup import logger
 from buttercup.bot import ButtercupBot
 
 EXTENSIONS = [
+    # The config cog has to be first!
+    "config",
     "admin",
     "handlers",
     "welcome",

--- a/buttercup/strings/en_US.yaml
+++ b/buttercup/strings/en_US.yaml
@@ -1,6 +1,4 @@
 handlers:
-  not_authorized: |
-    You are not authorized to use this command. This incident will be reported.
   no_username: |
     You did not provide a valid username. Either add it to the command or change your display name to a valid format.
   user_not_found: |


### PR DESCRIPTION
Relevant issue: Closes #133

## Description:

This reworks how the permissions for admin commands are handled.

Before, the permissions would be checked on command execution. When the user didn't have a specified role, the command would return an error message and log the incident.

Now, we are using the built-in permission system of slash commands. When a user doesn't have the required role in the guild, the admin commands will be grayed out and the user won't be able to execute them.

The implementation is a bit hacky, because the permissions are defined in annotations and we can't directly access the config from there. So now we define a global variable in a cog that we load first and then use that to generate the permissions.
This allows us to define the permissions in the config without hard-coding them in the annotation.

⚠️ This requires changing the config of the bot! ⚠️ 

## Checklist:

- [x] Code Quality
- [x] Pep-8
- [ ] Tests (if applicable)
- [x] Success Criteria Met
- [x] Inline Documentation
- [ ] Wiki Documentation (if applicable)
