### PR TITLE
Fix rate and history command throwing error when running for all users

### DIFF
--- a/buttercup/cogs/history.py
+++ b/buttercup/cogs/history.py
@@ -487,7 +487,8 @@ class History(Cog):
         )
 
         users = get_user_list(usernames, ctx, self.blossom_api)
-        users.sort(key=lambda u: u["gamma"], reverse=True)
+        if users:
+            users.sort(key=lambda u: u["gamma"], reverse=True)
         colors = get_user_colors(users)
 
         min_gammas = []
@@ -633,7 +634,8 @@ class History(Cog):
         )
 
         users = get_user_list(usernames, ctx, self.blossom_api)
-        users.sort(key=lambda u: u["gamma"], reverse=True)
+        if users:
+            users.sort(key=lambda u: u["gamma"], reverse=True)
         colors = get_user_colors(users)
 
         max_rates = []


### PR DESCRIPTION
Relevant issue: N/A

## Description:

This fixes a bug that resulted the `/rate` and `/history` commands in throwing an error when running them for all users.
The bot was trying to sort the users by gamma, but the users are `None` when running for everyone.

## Checklist:

- [x] Code Quality
- [x] Pep-8
- [ ] Tests (if applicable)
- [x] Success Criteria Met
- [x] Inline Documentation
- [ ] Wiki Documentation (if applicable)
