### PR TITLE
Respond with custom message when user has 0 gamma

### DIFF
--- a/buttercup/cogs/handlers.py
+++ b/buttercup/cogs/handlers.py
@@ -11,7 +11,7 @@ from buttercup.cogs.helpers import (
     InvalidArgumentException,
     NoUsernameException,
     TimeParseError,
-    UserNotFoundException,
+    UserNotFoundException, NewUserException,
 )
 from buttercup.strings import translation
 
@@ -45,6 +45,11 @@ class Handlers(commands.Cog):
             logger.warning(f"User '{error.username}' not found.", ctx)
             await ctx.send(
                 i18n["handlers"]["user_not_found"].format(user=error.username)
+            )
+        elif isinstance(error, NewUserException):
+            logger.warning(f"User '{error.username}' hasn't transcribed yet.", ctx)
+            await ctx.send(
+                i18n["handlers"]["new_user"].format(user=error.username)
             )
         elif isinstance(error, TimeParseError):
             logger.warning(

--- a/buttercup/cogs/handlers.py
+++ b/buttercup/cogs/handlers.py
@@ -9,9 +9,10 @@ from buttercup.bot import ButtercupBot
 from buttercup.cogs.helpers import (
     BlossomException,
     InvalidArgumentException,
+    NewUserException,
     NoUsernameException,
     TimeParseError,
-    UserNotFoundException, NewUserException,
+    UserNotFoundException,
 )
 from buttercup.strings import translation
 
@@ -48,9 +49,7 @@ class Handlers(commands.Cog):
             )
         elif isinstance(error, NewUserException):
             logger.warning(f"User '{error.username}' hasn't transcribed yet.", ctx)
-            await ctx.send(
-                i18n["handlers"]["new_user"].format(user=error.username)
-            )
+            await ctx.send(i18n["handlers"]["new_user"].format(user=error.username))
         elif isinstance(error, TimeParseError):
             logger.warning(
                 f"Command executed with an invalid time string '{error.time_str}'.", ctx

--- a/buttercup/cogs/helpers.py
+++ b/buttercup/cogs/helpers.py
@@ -48,6 +48,15 @@ class UserNotFoundException(DiscordException):
         self.username = username
 
 
+class NewUserException(DiscordException):
+    """Exception raised when a user has not started transcribing yet."""
+
+    def __init__(self, username: str) -> None:
+        """Create a new user exception."""
+        super().__init__()
+        self.username = username
+
+
 class NoUsernameException(DiscordException):
     """Exception raised when the username was not provided."""
 
@@ -185,7 +194,14 @@ def get_user(
     if user_response.status != BlossomStatus.ok:
         raise UserNotFoundException(_username)
 
-    return user_response.data
+    user = user_response.data
+
+    if user["gamma"] == 0:
+        # We don't have stats on new users
+        # They would often create an error so let's just handle them separately
+        raise NewUserException(user["username"])
+
+    return user
 
 
 def get_user_list(

--- a/buttercup/cogs/history.py
+++ b/buttercup/cogs/history.py
@@ -894,21 +894,6 @@ class History(Cog):
             )
         )
 
-        if user_gamma == 0:
-            # The user has not started transcribing yet
-            await msg.edit(
-                content=i18n["until"]["embed_message"].format(
-                    duration=get_duration_str(start), goal=goal_str, time_str=time_str,
-                ),
-                embed=Embed(
-                    title=i18n["until"]["embed_title"].format(user=get_username(user)),
-                    description=i18n["until"]["embed_description_new"].format(
-                        user=get_username(user)
-                    ),
-                ),
-            )
-            return
-
         description = await _get_progress_description(
             user,
             user_gamma,

--- a/buttercup/cogs/stats.py
+++ b/buttercup/cogs/stats.py
@@ -231,23 +231,6 @@ class Stats(Cog):
 
         user = get_user(username, ctx, self.blossom_api)
 
-        if user and user["gamma"] == 0:
-            # The user has not started transcribing yet
-            await msg.edit(
-                content=i18n["progress"]["embed_message"].format(
-                    user=get_username(user), duration=get_duration_str(start)
-                ),
-                embed=Embed(
-                    title=i18n["progress"]["embed_title"].format(
-                        user=get_username(user)
-                    ),
-                    description=i18n["progress"]["embed_description_new"].format(
-                        user=get_username(user)
-                    ),
-                ),
-            )
-            return
-
         from_str = after_time.isoformat() if after_time else None
         until_str = before_time.isoformat() if before_time else None
 

--- a/buttercup/strings/en_US.yaml
+++ b/buttercup/strings/en_US.yaml
@@ -3,6 +3,10 @@ handlers:
     You did not provide a valid username. Either add it to the command or change your display name to a valid format.
   user_not_found: |
     I couldn't find a user with the name u/{user}!
+  new_user: |
+    Hey **u/{user}**!
+    It looks like you **haven't started transribing** yet. Do you need any help to get started?
+    Feel free to ask any questions here or [send us a mod mail](<https://www.reddit.com/message/compose?to=/r/TranscribersOfReddit>).
   invalid_time_str: |
     "{time_str}" is an invalid date/time. Try something like "2021-08-04", "10:13" or "3 weeks ago".
   invalid_argument: |
@@ -71,10 +75,6 @@ progress:
     {message}
   embed_description_other: |
     {count} transcriptions {time_str}.
-  embed_description_new: |
-    Hey u/{user}!
-    It looks like you haven't started transribing yet. Do you need any help to get started?
-    Feel free to ask any questions here or [send us a mod mail](https://www.reddit.com/message/compose?to=/r/TranscribersOfReddit).
   motivational_messages:
     0:
       - Look who's slacking off.
@@ -202,10 +202,6 @@ until:
     **{user}** ({user_gamma:,} at {user_progress:,}/{time_frame}) has already reached **{goal}**!
   embed_description_zero: |
     **{user}** will **never** get from {user_gamma:,} to **{goal}** at this pace, they haven't transcribed anything in the past {time_frame}!
-  embed_description_new: |
-    Hey {user}!
-    It looks like you haven't started transribing yet. Do you need any help to get started?
-    Feel free to ask any questions here or [send us a mod mail](https://www.reddit.com/message/compose?to=/r/TranscribersOfReddit).
   embed_description_user_prediction: |
     **{user}** ({user_gamma:,}, {user_progress:,}/{time_frame}) will catch up with
     **{target}** ({target_gamma:,}, {target_progress:,}/{time_frame}) in {relative_time} ({absolute_time}) at {intersection_gamma:,} gamma!


### PR DESCRIPTION
Relevant issue: Closes #139

## Description:

When a user has zero gamma, but is in our database, it breaks most commands.
So instead we now throw a custom error when fetching the user and handle that at a central place.

## Screenshots:

![The bot responds with a custom message for a user that hasn't transcribed yet. It instructs them to ask questions or to write us a mod mail.](https://user-images.githubusercontent.com/13908946/147392542-71e7bd84-7dc6-4df8-8bb9-2236b22bd5ae.png)

## Checklist:

- [x] Code Quality
- [x] Pep-8
- [ ] Tests (if applicable)
- [x] Success Criteria Met
- [x] Inline Documentation
- [ ] Wiki Documentation (if applicable)
