### PR TITLE
Fix error when executing `/leaderboard` without after but with before time

### DIFF
--- a/buttercup/cogs/leaderboard.py
+++ b/buttercup/cogs/leaderboard.py
@@ -42,7 +42,10 @@ def format_leaderboard_timeframe(
     if not after and not before:
         return "all time"
 
-    delta = (before or datetime.now(tz=pytz.utc)) - (after or datetime(2017, 4, 1))
+    # 2017-04-01 is the start of the project
+    delta = (before or datetime.now(tz=pytz.utc)) - (
+        after or datetime(2017, 4, 1, tzinfo=pytz.utc)
+    )
 
     return get_timedelta_str(delta)
 


### PR DESCRIPTION
Relevant issue: Closes #141 

## Description:

The datetime that is used to calculate the duration of the leaderboard time when no after time was provided was timezone naive.
This resulted in a timezone error when the duration was calculated and made the command fail.
It now has UTC added to avoid this problem.

## Checklist:

- [x] Code Quality
- [x] Pep-8
- [ ] Tests (if applicable)
- [x] Success Criteria Met
- [x] Inline Documentation
- [ ] Wiki Documentation (if applicable)
