### PR TITLE
Don't preview NSFW content

### DIFF
--- a/buttercup/cogs/find.py
+++ b/buttercup/cogs/find.py
@@ -85,6 +85,8 @@ def to_embed(data: Dict) -> Embed:
     )
 
     submission = data.get("submission") or {}
+    is_nsfw = submission.get("nsfw") is True
+    link_text = "Link (NSFW)" if is_nsfw else "Link"
 
     # Add title
     if title := submission.get("title"):
@@ -92,7 +94,7 @@ def to_embed(data: Dict) -> Embed:
 
     # Add OCR status
     if ocr_url := (data.get("ocr") or {}).get("url"):
-        ocr_status = f"[Link]({ocr_url})"
+        ocr_status = f"[{link_text}]({ocr_url})"
     elif submission.get("has_ocr_transcription"):
         ocr_status = "Yes"
     else:
@@ -106,26 +108,26 @@ def to_embed(data: Dict) -> Embed:
 
     # Add image preview
     if content_url := submission.get("content_url"):
-        if not submission.get("nsfw"):
+        if not is_nsfw:
             # There is no way to mark the image as spoiler
             # Instead we just don't add the image if it's NSFW
             embed.set_image(url=content_url)
 
     # Add link to ToR post
     if tor_url := submission.get("tor_url"):
-        embed.add_field(name="ToR Post", value=f"[Link]({tor_url})")
+        embed.add_field(name="ToR Post", value=f"[{link_text}]({tor_url})")
 
     # Add link to partner post
     if sub_url := submission.get("url"):
         subreddit = sub_url.split("/")[4]
-        embed.add_field(name="Partner Post", value=f"[Link]({sub_url})")
+        embed.add_field(name="Partner Post", value=f"[{link_text}]({sub_url})")
         embed.set_author(
             name=f"r/{subreddit}", url=i18n["reddit"]["subreddit_url"].format(subreddit)
         )
 
     # Add link to transcription
     if tr_url := (data.get("transcription") or {}).get("url"):
-        tr_link = f"[Link]({tr_url})"
+        tr_link = f"[{link_text}]({tr_url})"
         embed.add_field(name="Transcription", value=tr_link)
 
     return embed

--- a/buttercup/cogs/find.py
+++ b/buttercup/cogs/find.py
@@ -86,6 +86,10 @@ def to_embed(data: Dict) -> Embed:
 
     submission = data.get("submission") or {}
 
+    # Add title
+    if title := submission.get("title"):
+        embed.title = title
+
     # Add OCR status
     if ocr_url := (data.get("ocr") or {}).get("url"):
         ocr_status = f"[Link]({ocr_url})"

--- a/buttercup/cogs/find.py
+++ b/buttercup/cogs/find.py
@@ -85,8 +85,10 @@ def to_embed(data: Dict) -> Embed:
     )
 
     submission = data.get("submission") or {}
-    is_nsfw = submission.get("nsfw") is True
-    link_text = "Link (NSFW)" if is_nsfw else "Link"
+    # Determine if the post is safe for work
+    # Otherwise we need to be careful about what content to preview
+    is_sfw = not submission.get("nsfw")
+    link_text = "Link" if is_sfw else "Link (NSFW)"
 
     # Add title
     if title := submission.get("title"):
@@ -102,13 +104,14 @@ def to_embed(data: Dict) -> Embed:
 
     embed.add_field(name="OCR", value=ocr_status)
 
-    # Add transcription text
-    if tr_text := get_clean_transcription(data):
-        embed.description = limit_str(tr_text, 200)
+    # Only preview content if it's safe for work
+    if is_sfw:
+        # Add transcription text
+        if tr_text := get_clean_transcription(data):
+            embed.description = limit_str(tr_text, 200)
 
-    # Add image preview
-    if content_url := submission.get("content_url"):
-        if not is_nsfw:
+        # Add image preview
+        if content_url := submission.get("content_url"):
             # There is no way to mark the image as spoiler
             # Instead we just don't add the image if it's NSFW
             embed.set_image(url=content_url)

--- a/buttercup/cogs/find.py
+++ b/buttercup/cogs/find.py
@@ -102,7 +102,10 @@ def to_embed(data: Dict) -> Embed:
 
     # Add image preview
     if content_url := submission.get("content_url"):
-        embed.set_image(url=content_url)
+        if not submission.get("nsfw"):
+            # There is no way to mark the image as spoiler
+            # Instead we just don't add the image if it's NSFW
+            embed.set_image(url=content_url)
 
     # Add link to ToR post
     if tor_url := submission.get("tor_url"):

--- a/buttercup/cogs/find.py
+++ b/buttercup/cogs/find.py
@@ -92,7 +92,7 @@ def to_embed(data: Dict) -> Embed:
 
     # Add title
     if title := submission.get("title"):
-        embed.title = title
+        embed.title = title if is_sfw else f"||{title}||"
 
     # Add OCR status
     if ocr_url := (data.get("ocr") or {}).get("url"):


### PR DESCRIPTION
Relevant issue: Closes #148

## Description:

We had the problem that the `/find` command previews images, even if they are NSFW. Volunteers don't have the ability to remove the bot's previews, so if they accidentally searched for something NSFW it was stuck in the chat.

Unfortunately, it's not possible to spoiler the preview images in embeds.

Instead, we now don't include the image and transcription preview if the post is marked NSFW.
The post links will now also include a note that the post is NSFW.

Additionally, this PR adds the post title to the `/find` response. If the post is NSFW, it will be spoilered.

Note that this all depends on the post being marked as NSFW in Blossom, not on Reddit.
So this will benefit from GrafeasGroup/blossom#263 being implemented.

## Screenshot:

![Response of the `/find` command for a NSFW post. The image and transcription preview is not included, the links include a NSFW disclaimer and the title is spoilered.](https://user-images.githubusercontent.com/13908946/147409445-8a6babe4-e8e7-48cd-9a03-695389d294f6.png)

## Checklist:

- [x] Code Quality
- [x] Pep-8
- [ ] Tests (if applicable)
- [x] Success Criteria Met
- [x] Inline Documentation
- [ ] Wiki Documentation (if applicable)
