### PR TITLE
Properly close heatmap figure after use

### DIFF
--- a/buttercup/cogs/heatmap.py
+++ b/buttercup/cogs/heatmap.py
@@ -66,7 +66,7 @@ def create_file_from_heatmap(
     heatmap_table = io.BytesIO()
     plt.savefig(heatmap_table, format="png")
     heatmap_table.seek(0)
-    plt.clf()
+    plt.close(fig)
 
     return File(heatmap_table, "heatmap_table.png")
 


### PR DESCRIPTION
Relevant issue: Closes #151

## Description:

The pyplot figures to create the heatmap weren't closed properly after use.
This resulted in them cluttering up the memory.

## Checklist:

- [x] Code Quality
- [x] Pep-8
- [ ] Tests (if applicable)
- [x] Success Criteria Met
- [ ] Inline Documentation
- [ ] Wiki Documentation (if applicable)
