### PR TITLE
Fix name change confirmation message

### DIFF
--- a/buttercup/cogs/helpers.py
+++ b/buttercup/cogs/helpers.py
@@ -12,7 +12,9 @@ from requests import Response
 
 from buttercup.cogs import ranks
 
-username_regex = re.compile(r"^(?P<prefix>(?P<leading_slash>/)?u/)?(?P<username>\S+)(?P<rest>.*)$")
+username_regex = re.compile(
+    r"^(?P<prefix>(?P<leading_slash>/)?u/)?(?P<username>\S+)(?P<rest>.*)$"
+)
 timezone_regex = re.compile(r"UTC(?P<offset>[+-]\d+)?", re.RegexFlag.I)
 
 # First an amount and then a unit
@@ -291,10 +293,19 @@ def extract_sub_name(subreddit: str) -> str:
 
 def extract_utc_offset(display_name: str) -> int:
     """Extract the user's timezone (UTC offset) from the display name."""
-    match = timezone_regex.search(display_name)
-    if match is None or match.group("offset") is None:
+    username_match = username_regex.match(display_name)
+    if username_match is None:
         return 0
-    return int(match.group("offset"))
+
+    if rest := username_match.group("rest"):
+        timezone_match = timezone_regex.search(rest)
+        if timezone_match is None:
+            return 0
+
+        if offset := timezone_match.group("offset"):
+            return int(offset)
+
+    return 0
 
 
 def get_duration_str(start: datetime) -> str:

--- a/buttercup/cogs/helpers.py
+++ b/buttercup/cogs/helpers.py
@@ -12,7 +12,7 @@ from requests import Response
 
 from buttercup.cogs import ranks
 
-username_regex = re.compile(r"^(?:/?u/)?(?P<username>\S+)")
+username_regex = re.compile(r"^(?P<prefix>(?P<leading_slash>/)?u/)?(?P<username>\S+)(?P<rest>.+)?$")
 timezone_regex = re.compile(r"UTC(?P<offset>[+-]\d+)?", re.RegexFlag.I)
 
 # First an amount and then a unit

--- a/buttercup/cogs/helpers.py
+++ b/buttercup/cogs/helpers.py
@@ -12,7 +12,7 @@ from requests import Response
 
 from buttercup.cogs import ranks
 
-username_regex = re.compile(r"^(?P<prefix>(?P<leading_slash>/)?u/)?(?P<username>\S+)(?P<rest>.+)?$")
+username_regex = re.compile(r"^(?P<prefix>(?P<leading_slash>/)?u/)?(?P<username>\S+)(?P<rest>.*)$")
 timezone_regex = re.compile(r"UTC(?P<offset>[+-]\d+)?", re.RegexFlag.I)
 
 # First an amount and then a unit

--- a/buttercup/cogs/name_validator.py
+++ b/buttercup/cogs/name_validator.py
@@ -75,7 +75,11 @@ class NameValidator(Cog):
 
         before_match = username_regex.search(before_name)
 
-        if before_match and before_match.group("leading_slash"):
+        if (
+            before_match
+            and before_match.group("prefix")
+            and before_match.group("leading_slash")
+        ):
             # The username was correct already and is still correct
             # For example timezone change, we don't have to send a message
             # Still set the role, just to be safe

--- a/buttercup/cogs/name_validator.py
+++ b/buttercup/cogs/name_validator.py
@@ -7,12 +7,10 @@ from discord.member import Member
 
 from buttercup import logger
 from buttercup.bot import ButtercupBot
+from buttercup.cogs.helpers import username_regex
 from buttercup.strings import translation
 
 i18n = translation()
-
-
-username_regex = re.compile(r"^(?P<leading_slash>/)?u/(?P<username>\S+)(?P<rest>.+)$")
 
 
 class NameValidator(Cog):
@@ -45,7 +43,7 @@ class NameValidator(Cog):
             logger.warning("No welcome channel defined. Can't validate nicknames!")
 
         after_match = username_regex.search(after_name)
-        if after_match is None:
+        if after_match is None or after_match.group("prefix") is None:
             # Invalid nickname, remove the verified role
             await after.remove_roles(verified_role, reason="Invalid nickname")
             await welcome_channel.send(

--- a/buttercup/cogs/name_validator.py
+++ b/buttercup/cogs/name_validator.py
@@ -1,4 +1,3 @@
-import re
 from typing import Optional
 
 from discord import Forbidden, TextChannel

--- a/test/test_helpers.py
+++ b/test/test_helpers.py
@@ -16,8 +16,31 @@ from buttercup.cogs.helpers import (
     get_username,
     join_items_with_and,
     parse_time_constraints,
-    try_parse_time,
+    try_parse_time, username_regex,
 )
+
+
+@mark.parametrize(
+    "input_str,prefix,leading_slash,username,rest",
+    [
+        ("user", None, False, "user", ""),
+        ("u/user", "u/", False, "user", ""),
+        ("/u/user", "/u/", True, "user", ""),
+        ("/u/user-name_with123stuff", "/u/", True, "user-name_with123stuff", ""),
+        ("/u/user [mod] UTC-3 ~40⭐", "/u/", True, "user", " [mod] UTC-3 ~40⭐"),
+    ],
+)
+def test_username_regex(
+    input_str: str, prefix: str, leading_slash: bool, username: str, rest: str
+) -> None:
+    """Test that the user name is extracted correctly."""
+    match = username_regex.match(input_str)
+    assert match is not None
+
+    assert match.group("prefix") == prefix
+    assert match.group("leading_slash") == ("/" if leading_slash else None)
+    assert match.group("username") == username
+    assert match.group("rest") == rest
 
 
 @mark.parametrize(

--- a/test/test_helpers.py
+++ b/test/test_helpers.py
@@ -16,7 +16,8 @@ from buttercup.cogs.helpers import (
     get_username,
     join_items_with_and,
     parse_time_constraints,
-    try_parse_time, username_regex,
+    try_parse_time,
+    username_regex,
 )
 
 


### PR DESCRIPTION
Relevant issue: Closes #155

## Description:

The name change confirmation message would cut off the last character of the username, if the user didn't include their timezone in the nickname.

This PR merges the username regex from the name validator and helper functions and fixes this bug along the way. I also added more tests to verify that it works correctly.

## Checklist:

- [x] Code Quality
- [x] Pep-8
- [x] Tests (if applicable)
- [x] Success Criteria Met
- [x] Inline Documentation
- [ ] Wiki Documentation (if applicable)
