### PR TITLE
Improve timezone handling

### DIFF
--- a/buttercup/cogs/heatmap.py
+++ b/buttercup/cogs/heatmap.py
@@ -21,7 +21,7 @@ from buttercup.cogs.helpers import (
     get_user,
     get_user_id,
     get_username,
-    parse_time_constraints,
+    parse_time_constraints, utc_offset_to_str,
 )
 from buttercup.strings import translation
 
@@ -56,7 +56,7 @@ def create_file_from_heatmap(
         yticklabels=days,
     )
 
-    timezone = "UTC" if utc_offset == 0 else f"UTC{utc_offset:+d}"
+    timezone = utc_offset_to_str(utc_offset)
 
     plt.title(i18n["heatmap"]["plot_title"].format(user=get_username(user)))
     plt.xlabel(i18n["heatmap"]["plot_xlabel"].format(timezone=timezone))

--- a/buttercup/cogs/heatmap.py
+++ b/buttercup/cogs/heatmap.py
@@ -1,6 +1,6 @@
 import io
 from datetime import datetime
-from typing import Any, Dict, Optional
+from typing import Optional
 
 import matplotlib.pyplot as plt
 import pandas as pd
@@ -21,7 +21,8 @@ from buttercup.cogs.helpers import (
     get_user,
     get_user_id,
     get_username,
-    parse_time_constraints, utc_offset_to_str,
+    parse_time_constraints,
+    utc_offset_to_str,
 )
 from buttercup.strings import translation
 

--- a/buttercup/cogs/heatmap.py
+++ b/buttercup/cogs/heatmap.py
@@ -71,15 +71,6 @@ def create_file_from_heatmap(
     return File(heatmap_table, "heatmap_table.png")
 
 
-def adjust_with_timezone(hour_data: Dict[str, Any], utc_offset: int) -> Dict[str, Any]:
-    """Adjust the heatmap data according to the UTC offset of the user."""
-    hour_offset = hour_data["hour"] + utc_offset
-    new_hour = hour_offset % 24
-    # The days go from 1 to 7, so we need to adjust this to zero index and back
-    new_day = ((hour_data["day"] + hour_offset // 24) - 1) % 7 + 1
-    return {"day": new_day, "hour": new_hour, "count": hour_data["count"]}
-
-
 class Heatmap(Cog):
     def __init__(self, bot: ButtercupBot, blossom_api: BlossomAPI) -> None:
         """Initialize the Heatmap cog."""
@@ -139,6 +130,7 @@ class Heatmap(Cog):
             "submission/heatmap/",
             params={
                 "completed_by": get_user_id(user),
+                "utc_offset": utc_offset,
                 "complete_time__gte": from_str,
                 "complete_time__lte": until_str,
             },
@@ -147,7 +139,6 @@ class Heatmap(Cog):
             raise BlossomException(heatmap_response)
 
         data = heatmap_response.json()
-        data = [adjust_with_timezone(hour_data, utc_offset) for hour_data in data]
 
         day_index = pd.Index(range(1, 8))
         hour_index = pd.Index(range(0, 24))

--- a/buttercup/cogs/helpers.py
+++ b/buttercup/cogs/helpers.py
@@ -16,7 +16,9 @@ from buttercup.cogs import ranks
 username_regex = re.compile(
     r"^(?P<prefix>(?P<leading_slash>/)?u/)?(?P<username>\S+)(?P<rest>.*)$"
 )
-timezone_regex = re.compile(r"UTC(?:(?P<hours>[+-]\d+(?:\.\d+)?)(?::(?P<minutes>\d+))?)?", re.RegexFlag.I)
+timezone_regex = re.compile(
+    r"UTC(?:(?P<hours>[+-]\d+(?:\.\d+)?)(?::(?P<minutes>\d+))?)?", re.RegexFlag.I
+)
 
 # First an amount and then a unit
 relative_time_regex = re.compile(
@@ -319,7 +321,7 @@ def extract_utc_offset(display_name: str) -> int:
 
 
 def utc_offset_to_str(utc_offset: int) -> str:
-    """Converts a UTC offset to a readable string.
+    """Convert a UTC offset to a readable string.
 
     :param utc_offset: The UTC offset in seconds.
     """

--- a/buttercup/cogs/helpers.py
+++ b/buttercup/cogs/helpers.py
@@ -292,7 +292,10 @@ def extract_sub_name(subreddit: str) -> str:
 
 
 def extract_utc_offset(display_name: str) -> int:
-    """Extract the user's timezone (UTC offset) from the display name."""
+    """Extract the user's timezone (UTC offset) from the display name.
+
+    :returns: The UTC offset in seconds.
+    """
     username_match = username_regex.match(display_name)
     if username_match is None:
         return 0
@@ -303,7 +306,7 @@ def extract_utc_offset(display_name: str) -> int:
             return 0
 
         if offset := timezone_match.group("offset"):
-            return int(offset)
+            return int(offset) * 60 * 60
 
     return 0
 

--- a/buttercup/cogs/helpers.py
+++ b/buttercup/cogs/helpers.py
@@ -311,6 +311,17 @@ def extract_utc_offset(display_name: str) -> int:
     return 0
 
 
+def utc_offset_to_str(utc_offset: int) -> str:
+    """Converts a UTC offset to a readable string.
+
+    :param utc_offset: The UTC offset in seconds.
+    """
+    sign = "-" if utc_offset < 0 else "+"
+    hours = abs(utc_offset) // (60 * 60)
+    minutes = abs(utc_offset) % (60 * 60)
+    return f"UTC{sign}{hours:02}:{minutes:02}"
+
+
 def get_duration_str(start: datetime) -> str:
     """Get the processing duration based on the start time."""
     duration = datetime.now(tz=start.tzinfo) - start

--- a/buttercup/cogs/history.py
+++ b/buttercup/cogs/history.py
@@ -21,6 +21,7 @@ from buttercup.cogs.helpers import (
     BlossomException,
     BlossomUser,
     InvalidArgumentException,
+    extract_utc_offset,
     get_discord_time_str,
     get_duration_str,
     get_initial_username,
@@ -35,7 +36,6 @@ from buttercup.cogs.helpers import (
     get_username,
     get_usernames,
     parse_time_constraints,
-    extract_utc_offset,
     utc_offset_to_str,
 )
 from buttercup.strings import translation

--- a/buttercup/cogs/history.py
+++ b/buttercup/cogs/history.py
@@ -35,6 +35,8 @@ from buttercup.cogs.helpers import (
     get_username,
     get_usernames,
     parse_time_constraints,
+    extract_utc_offset,
+    utc_offset_to_str,
 )
 from buttercup.strings import translation
 
@@ -339,6 +341,7 @@ class History(Cog):
         time_frame: str,
         after_time: Optional[datetime],
         before_time: Optional[datetime],
+        utc_offset: int,
     ) -> pd.DataFrame:
         """Get all rate data for the given user."""
         page_size = 500
@@ -361,6 +364,7 @@ class History(Cog):
                     "time_frame": time_frame,
                     "complete_time__gte": from_str,
                     "complete_time__lte": until_str,
+                    "utc_offset": utc_offset,
                 },
             )
             if response.status_code != 200:
@@ -423,6 +427,7 @@ class History(Cog):
         user: Optional[BlossomUser],
         after_time: Optional[datetime],
         before_time: Optional[datetime],
+        utc_offset: int,
     ) -> pd.DataFrame:
         """Get a data frame representing the history of the user.
 
@@ -430,7 +435,9 @@ class History(Cog):
         """
         # Get all rate data
         time_frame = get_data_granularity(user, after_time, before_time)
-        rate_data = self.get_all_rate_data(user, time_frame, after_time, before_time)
+        rate_data = self.get_all_rate_data(
+            user, time_frame, after_time, before_time, utc_offset
+        )
 
         # Calculate the offset for all data points
         offset = self.calculate_history_offset(user, rate_data, after_time, before_time)
@@ -465,7 +472,7 @@ class History(Cog):
             ),
         ],
     )
-    async def _history(
+    async def history(
         self,
         ctx: SlashContext,
         usernames: str = "me",
@@ -476,6 +483,8 @@ class History(Cog):
         start = datetime.now()
 
         after_time, before_time, time_str = parse_time_constraints(after, before)
+
+        utc_offset = extract_utc_offset(ctx.author.display_name)
 
         # Give a quick response to let the user know we're working on it
         # We'll later edit this message with the actual content
@@ -497,7 +506,11 @@ class History(Cog):
         ax: plt.Axes = fig.gca()
 
         fig.subplots_adjust(bottom=0.2)
-        ax.set_xlabel(i18n["history"]["plot_xlabel"])
+        ax.set_xlabel(
+            i18n["history"]["plot_xlabel"].format(
+                timezone=utc_offset_to_str(utc_offset)
+            )
+        )
         ax.set_ylabel(i18n["history"]["plot_ylabel"])
 
         for label in ax.get_xticklabels():
@@ -521,7 +534,9 @@ class History(Cog):
                     )
                 )
 
-            history_data = self.get_user_history(user, after_time, before_time)
+            history_data = self.get_user_history(
+                user, after_time, before_time, utc_offset
+            )
 
             color = colors[index]
             first_point = history_data.iloc[0]
@@ -590,7 +605,7 @@ class History(Cog):
             ),
         ],
     )
-    async def _rate(
+    async def rate(
         self,
         ctx: SlashContext,
         usernames: str = "me",
@@ -601,6 +616,8 @@ class History(Cog):
         start = datetime.now()
 
         after_time, before_time, time_str = parse_time_constraints(after, before)
+
+        utc_offset = extract_utc_offset(ctx.author.display_name)
 
         # Give a quick response to let the user know we're working on it
         # We'll later edit this message with the actual content
@@ -621,7 +638,9 @@ class History(Cog):
         ax: plt.Axes = fig.gca()
 
         fig.subplots_adjust(bottom=0.2)
-        ax.set_xlabel(i18n["rate"]["plot_xlabel"])
+        ax.set_xlabel(
+            i18n["rate"]["plot_xlabel"].format(timezone=utc_offset_to_str(utc_offset))
+        )
         ax.set_ylabel(i18n["rate"]["plot_ylabel"])
 
         for label in ax.get_xticklabels():
@@ -645,7 +664,9 @@ class History(Cog):
                     )
                 )
 
-            user_data = self.get_all_rate_data(user, "day", after_time, before_time)
+            user_data = self.get_all_rate_data(
+                user, "day", after_time, before_time, utc_offset
+            )
 
             max_rate = user_data["count"].max()
             max_rates.append(max_rate)

--- a/buttercup/strings/en_US.yaml
+++ b/buttercup/strings/en_US.yaml
@@ -242,7 +242,7 @@ history:
     getting_history_progress: |
       Creating the history graph for {users} {time_str} ({count}/{total})...
     plot_title: History of {users}
-    plot_xlabel: Time
+    plot_xlabel: Time ({timezone})
     plot_ylabel: Gamma
     response_message:
       Here is the history graph for {users} {time_str}! ({duration})
@@ -252,7 +252,7 @@ rate:
     getting_rate_progress: |
       Creating the transcription rate graph for {users} {time_str} ({count}/{total})...
     plot_title: Transcription Rate of {users}
-    plot_xlabel: Time
+    plot_xlabel: Time ({timezone})
     plot_ylabel: Transcription Rate
     response_message:
       Here is the transcription rate graph for {usernames} {time_str}! ({duration})

--- a/test/test_helpers.py
+++ b/test/test_helpers.py
@@ -17,7 +17,8 @@ from buttercup.cogs.helpers import (
     join_items_with_and,
     parse_time_constraints,
     try_parse_time,
-    username_regex, utc_offset_to_str,
+    username_regex,
+    utc_offset_to_str,
 )
 
 
@@ -141,7 +142,7 @@ def test_extract_utc_offset(name_input: str, expected: int) -> None:
         (-18_000, "UTC-05:00"),
         (14_400, "UTC+04:00"),
         (3_600, "UTC+01:00"),
-        (37_800, "UTC+10:30")
+        (37_800, "UTC+10:30"),
     ],
 )
 def test_utc_offset_to_str(utc_offset: int, expected: str) -> None:

--- a/test/test_helpers.py
+++ b/test/test_helpers.py
@@ -117,10 +117,14 @@ def test_escape_formatting(username: str, expected: str) -> None:
         ("u/username", 0),
         ("/u/username [mod] ~20⭐", 0),
         ("/u/username UTC", 0),
+        ("/u/UTC+10", 0),
         ("/u/username UTC+2", 7_200),
         ("/u/username UTC-5", -18_000),
         ("/u/username utc+4", 14400),
         ("/u/username [mod] UTC+1 - 14⭐", 3600),
+        ("/u/username UTC+02:00", 7_200),
+        ("/u/username UTC+10.5", 37_800),
+        ("/u/username UTC+10:30", 37_800),
     ],
 )
 def test_extract_utc_offset(name_input: str, expected: int) -> None:
@@ -135,8 +139,9 @@ def test_extract_utc_offset(name_input: str, expected: int) -> None:
         (0, "UTC+00:00"),
         (7_200, "UTC+02:00"),
         (-18_000, "UTC-05:00"),
-        (14400, "UTC+04:00"),
-        (3600, "UTC+01:00"),
+        (14_400, "UTC+04:00"),
+        (3_600, "UTC+01:00"),
+        (37_800, "UTC+10:30")
     ],
 )
 def test_utc_offset_to_str(utc_offset: int, expected: str) -> None:

--- a/test/test_helpers.py
+++ b/test/test_helpers.py
@@ -17,7 +17,7 @@ from buttercup.cogs.helpers import (
     join_items_with_and,
     parse_time_constraints,
     try_parse_time,
-    username_regex,
+    username_regex, utc_offset_to_str,
 )
 
 
@@ -126,6 +126,22 @@ def test_escape_formatting(username: str, expected: str) -> None:
 def test_extract_utc_offset(name_input: str, expected: int) -> None:
     """Test that the UTC offset is extracted correctly."""
     actual = extract_utc_offset(name_input)
+    assert actual == expected
+
+
+@mark.parametrize(
+    "utc_offset,expected",
+    [
+        (0, "UTC+00:00"),
+        (7_200, "UTC+02:00"),
+        (-18_000, "UTC-05:00"),
+        (14400, "UTC+04:00"),
+        (3600, "UTC+01:00"),
+    ],
+)
+def test_utc_offset_to_str(utc_offset: int, expected: str) -> None:
+    """Test that the UTC offset is extracted correctly."""
+    actual = utc_offset_to_str(utc_offset)
     assert actual == expected
 
 

--- a/test/test_helpers.py
+++ b/test/test_helpers.py
@@ -117,10 +117,10 @@ def test_escape_formatting(username: str, expected: str) -> None:
         ("u/username", 0),
         ("/u/username [mod] ~20⭐", 0),
         ("/u/username UTC", 0),
-        ("/u/username UTC+2", 2),
-        ("/u/username UTC-5", -5),
-        ("/u/username utc+4", 4),
-        ("/u/username [mod] UTC+1 - 14⭐", 1),
+        ("/u/username UTC+2", 7_200),
+        ("/u/username UTC-5", -18_000),
+        ("/u/username utc+4", 14400),
+        ("/u/username [mod] UTC+1 - 14⭐", 3600),
     ],
 )
 def test_extract_utc_offset(name_input: str, expected: int) -> None:


### PR DESCRIPTION
Relevant issue: Closes #145

## Description:

This PR includes several improvements to how timezone localization is handled:
- Timezones can now include a minute fraction (e.g. `UTC+10.5` or `UTC-05:30`)
- Timezone localization is now handled by the server instead of Buttercup itself
- Added timezone localization to `/rate` and `/history` graphs

## Screenshots:

![The `/heatmap` command for u/SammyzABanana with a UTC+10:30 offset.](https://user-images.githubusercontent.com/13908946/148211897-fd136c36-900f-4919-a43c-3ec55b008659.png)

## Future Work:

Currently the timezone of the user executing the command is used for all command executions.
If you execute the command for another user, it will still use your timezone.

In the future, we should cache the timezone of a user if they execute a command or change their nickname and then use the target's timezone instead of your own timezone.
Additionally, we could add an optional command parameter to specify a custom timezone.

## Checklist:

- [x] Code Quality
- [x] Pep-8
- [x] Tests (if applicable)
- [x] Success Criteria Met
- [x] Inline Documentation
- [ ] Wiki Documentation (if applicable)
