### PR TITLE
Fix pagination not working for `/search` results

### DIFF
--- a/buttercup/cogs/search.py
+++ b/buttercup/cogs/search.py
@@ -312,7 +312,7 @@ class Search(Cog):
             return
 
         # Only cache the result if the user can change pages
-        if response_data["count"] <= self.discord_page_size:
+        if response_data["count"] > self.discord_page_size:
             # Update the cache
             self.cache.set(
                 msg.id,


### PR DESCRIPTION
Relevant issue: Closes #163

## Description:

While implementing an optimization I accidentally broke the pagination.
Instead of caching only responses with multiple pages, it cached only responses with a single page.
Thus, when reacting, the message was never in the cache.

## Checklist:

- [x] Code Quality
- [x] Pep-8
- [ ] Tests (if applicable)
- [x] Success Criteria Met
- [ ] Inline Documentation
- [ ] Wiki Documentation (if applicable)
