### PR TITLE
Add `/queue` command

### DIFF
--- a/buttercup/cogs/helpers.py
+++ b/buttercup/cogs/helpers.py
@@ -398,7 +398,7 @@ def get_discord_time_str(date_time: datetime, style: str = "f") -> str:
     Style should be one of the timestamp styles defined here:
     https://discord.com/developers/docs/reference#message-formatting-timestamp-styles
     """
-    timestamp = mktime(date_time.timetuple())
+    timestamp = date_time.timestamp()
     # https://discord.com/developers/docs/reference#message-formatting-formats
     return f"<t:{timestamp:0.0f}:{style}>"
 

--- a/buttercup/cogs/helpers.py
+++ b/buttercup/cogs/helpers.py
@@ -2,7 +2,7 @@ import math
 import re
 from datetime import datetime, timedelta
 from time import mktime
-from typing import Dict, List, Optional, Tuple, TypedDict, Union, Any
+from typing import Any, Dict, List, Optional, Tuple, TypedDict, Union
 
 import pytz
 from blossom_wrapper import BlossomAPI, BlossomResponse, BlossomStatus

--- a/buttercup/cogs/helpers.py
+++ b/buttercup/cogs/helpers.py
@@ -2,7 +2,7 @@ import math
 import re
 from datetime import datetime, timedelta
 from time import mktime
-from typing import Dict, List, Optional, Tuple, TypedDict, Union
+from typing import Dict, List, Optional, Tuple, TypedDict, Union, Any
 
 import pytz
 from blossom_wrapper import BlossomAPI, BlossomResponse, BlossomStatus
@@ -513,3 +513,19 @@ def get_rgb_from_hex(hex_str: str) -> Tuple[int, int, int]:
     # https://stackoverflow.com/questions/29643352/converting-hex-to-rgb-value-in-python
     hx = hex_str.lstrip("#")
     return int(hx[0:2], 16), int(hx[2:4], 16), int(hx[4:6], 16)
+
+
+def extract_sub_from_url(url: str) -> str:
+    """Extract the subreddit from a Reddit URL."""
+    # https://reddit.com/r/thatHappened/comments/qzhtyb/the_more_you_read_the_less_believable_it_gets/hlmkuau/
+    return "r/" + url.split("/")[4]
+
+
+def get_transcription_source(transcription: Dict[str, Any]) -> str:
+    """Try to determine the source (subreddit) of the transcription."""
+    return extract_sub_from_url(transcription["url"])
+
+
+def get_submission_source(submission: Dict[str, Any]) -> str:
+    """Try to determine the source (subreddit) of the submission."""
+    return extract_sub_from_url(submission["url"])

--- a/buttercup/cogs/helpers.py
+++ b/buttercup/cogs/helpers.py
@@ -1,7 +1,6 @@
 import math
 import re
 from datetime import datetime, timedelta
-from time import mktime
 from typing import Any, Dict, List, Optional, Tuple, TypedDict, Union
 
 import pytz

--- a/buttercup/cogs/queue.py
+++ b/buttercup/cogs/queue.py
@@ -1,30 +1,18 @@
-import asyncio
-import math
-import re
 from datetime import datetime, timedelta
-from typing import Any, Dict, List, Optional, TypedDict
+from typing import Dict, Optional
 
 import pandas as pd
 import pytz
 from blossom_wrapper import BlossomAPI
-from dateutil import parser
-from discord import Embed, Forbidden, Reaction, User
-from discord.ext import commands
+from discord import Embed
 from discord.ext.commands import Cog
 from discord_slash import SlashContext, cog_ext
-from discord_slash.model import SlashMessage
 from discord_slash.utils.manage_commands import create_option
 
 from buttercup.bot import ButtercupBot
 from buttercup.cogs.helpers import (
     BlossomException,
-    BlossomUser,
-    get_discord_time_str,
     get_duration_str,
-    get_initial_username,
-    get_user,
-    get_username,
-    parse_time_constraints,
     get_submission_source,
 )
 from buttercup.strings import translation
@@ -41,7 +29,10 @@ def fix_submission_source(submission: Dict) -> Dict:
 
 
 def get_source_list(sources: pd.Series) -> str:
-    items = [f"- {count} from **{source}**" for source, count in sources.head(5).iteritems()]
+    """Get a list of the posts grouped by sources."""
+    items = [
+        f"- {count} from **{source}**" for source, count in sources.head(5).iteritems()
+    ]
     result = "\n".join(items)
 
     if len(sources) > 5:

--- a/buttercup/cogs/queue.py
+++ b/buttercup/cogs/queue.py
@@ -124,16 +124,8 @@ class Queue(Cog):
     @cog_ext.cog_slash(
         name="queue",
         description="Display the current status of the queue.",
-        options=[
-            create_option(
-                name="source",
-                description="The source (subreddit) to filter the queue by.",
-                option_type=3,
-                required=False,
-            ),
-        ],
     )
-    async def queue(self, ctx: SlashContext, source: Optional[str] = None,) -> None:
+    async def queue(self, ctx: SlashContext) -> None:
         """Display the current status of the queue."""
         # Send a first message to show that the bot is responsive.
         # We will edit this message later with the actual content.

--- a/buttercup/cogs/queue.py
+++ b/buttercup/cogs/queue.py
@@ -31,7 +31,8 @@ def fix_submission_source(submission: Dict) -> Dict:
 def get_source_list(sources: pd.Series) -> str:
     """Get a list of the posts grouped by sources."""
     items = [
-        f"- {count} from **{source}**" for source, count in sources.head(5).iteritems()
+        i18n["queue"]["source_list_entry"].format(count=count, source=source)
+        for source, count in sources.head(5).iteritems()
     ]
     result = "\n".join(items)
 
@@ -39,7 +40,9 @@ def get_source_list(sources: pd.Series) -> str:
         rest = sources[5:]
         source_count = len(rest)
         post_count = rest.sum()
-        result += f"\n...and {post_count} from {source_count} other source(s)."
+        result += "\n" + i18n["queue"]["source_list_others"].format(
+            post_count=post_count, source_count=source_count
+        )
 
     return result
 
@@ -116,6 +119,14 @@ class Queue(Cog):
         )
         source_list = get_source_list(sources)
 
+        unclaimed_message = (
+            i18n["queue"]["unclaimed_message_cleared"]
+            if unclaimed_count == 0
+            else i18n["queue"]["unclaimed_message"].format(
+                unclaimed_count=unclaimed_count, source_list=source_list,
+            )
+        )
+
         await msg.edit(
             content=i18n["queue"]["embed_message"].format(
                 duration_str=get_duration_str(start),
@@ -123,7 +134,7 @@ class Queue(Cog):
             embed=Embed(
                 title=i18n["queue"]["embed_title"],
                 description=i18n["queue"]["embed_description"].format(
-                    unclaimed_count=unclaimed_count, source_list=source_list,
+                    unclaimed_message=unclaimed_message
                 ),
             ),
         )

--- a/buttercup/cogs/queue.py
+++ b/buttercup/cogs/queue.py
@@ -60,6 +60,7 @@ def get_claimed_item(submission: pd.Series, user_cache: Dict) -> str:
     """Get the formatted submission item."""
     source = submission["source"]
     time_str = submission["claim_time"]
+    url = submission["tor_url"]
     author_url = submission["claimed_by"]
 
     time = get_discord_time_str(dateutil.parser.parse(time_str), style="R")
@@ -67,7 +68,7 @@ def get_claimed_item(submission: pd.Series, user_cache: Dict) -> str:
     author = user_cache.get(author_id, {"username": author_id})
 
     return i18n["queue"]["claimed_list_entry"].format(
-        source=source, time=time, author="u/" + author["username"],
+        author="u/" + author["username"], source=source, url=url, time=time,
     )
 
 

--- a/buttercup/cogs/queue.py
+++ b/buttercup/cogs/queue.py
@@ -16,8 +16,8 @@ from buttercup.bot import ButtercupBot
 from buttercup.cogs.find import COMPLETED_COLOR, IN_PROGRESS_COLOR, UNCLAIMED_COLOR
 from buttercup.cogs.helpers import (
     BlossomException,
-    get_submission_source,
     get_discord_time_str,
+    get_submission_source,
 )
 from buttercup.strings import translation
 
@@ -27,6 +27,7 @@ i18n = translation()
 
 
 def extract_user_id(user_url: str) -> str:
+    """Extract the ID from a Blossom user URL."""
     return user_url.split("/")[-2]
 
 
@@ -106,12 +107,12 @@ class Queue(Cog):
         self.update_cycle.start()
 
     @tasks.loop(minutes=1)
-    async def update_cycle(self):
+    async def update_cycle(self) -> None:
         """Keep everything up-to-date."""
         await self.update_queue()
         await self.update_messages()
 
-    async def update_queue(self):
+    async def update_queue(self) -> None:
         """Update the cached queue items."""
         self.unclaimed = await self.get_unclaimed_submissions()
         self.claimed = await self.get_claimed_submissions()
@@ -119,7 +120,7 @@ class Queue(Cog):
 
         self.last_update = datetime.now()
 
-    async def update_messages(self):
+    async def update_messages(self) -> None:
         """Update all messages with the latest queue stats."""
         for msg in self.messages:
             await self.update_message(msg)
@@ -195,7 +196,7 @@ class Queue(Cog):
         data_frame = pd.DataFrame.from_records(data=results, index="id")
         return data_frame
 
-    def update_user_cache(self):
+    def update_user_cache(self) -> None:
         """Fetch the users from their IDs."""
         user_cache = {}
 
@@ -214,7 +215,7 @@ class Queue(Cog):
 
         self.user_cache = user_cache
 
-    def add_message(self, msg: SlashMessage):
+    def add_message(self, msg: SlashMessage) -> None:
         """Add a new message to update with the current queue stats.
 
         This enforces a maximum amount of messages that should
@@ -236,7 +237,7 @@ class Queue(Cog):
         # Keep the message updated in the future
         self.add_message(msg)
 
-    async def update_message(self, msg: SlashMessage):
+    async def update_message(self, msg: SlashMessage) -> None:
         """Update the given message with the latest queue stats."""
         unclaimed = self.unclaimed
         unclaimed_count = len(unclaimed.index)

--- a/buttercup/cogs/queue.py
+++ b/buttercup/cogs/queue.py
@@ -106,7 +106,7 @@ class Queue(Cog):
         logger.info("Starting queue update cycle...")
         self.update_cycle.start()
 
-    @tasks.loop(minutes=1)
+    @tasks.loop(minutes=2)
     async def update_cycle(self) -> None:
         """Keep everything up-to-date."""
         await self.update_queue()

--- a/buttercup/cogs/queue.py
+++ b/buttercup/cogs/queue.py
@@ -1,0 +1,78 @@
+import asyncio
+import math
+import re
+from datetime import datetime
+from typing import Any, Dict, List, Optional, TypedDict
+
+import pytz
+from blossom_wrapper import BlossomAPI
+from dateutil import parser
+from discord import Embed, Forbidden, Reaction, User
+from discord.ext import commands
+from discord.ext.commands import Cog
+from discord_slash import SlashContext, cog_ext
+from discord_slash.model import SlashMessage
+from discord_slash.utils.manage_commands import create_option
+
+from buttercup.bot import ButtercupBot
+from buttercup.cogs.helpers import (
+    BlossomException,
+    BlossomUser,
+    get_discord_time_str,
+    get_duration_str,
+    get_initial_username,
+    get_user,
+    get_username,
+    parse_time_constraints,
+)
+from buttercup.strings import translation
+
+i18n = translation()
+
+
+class Queue(Cog):
+    def __init__(self, bot: ButtercupBot, blossom_api: BlossomAPI) -> None:
+        """Initialize the Queue cog."""
+        self.bot = bot
+        self.blossom_api = blossom_api
+
+    @cog_ext.cog_slash(
+        name="queue",
+        description="Display the current status of the queue.",
+        options=[
+            create_option(
+                name="source",
+                description="The source (subreddit) to filter the queue by.",
+                option_type=3,
+                required=False,
+            ),
+        ],
+    )
+    async def queue(self, ctx: SlashContext, source: Optional[str] = None,) -> None:
+        """Display the current status of the queue."""
+        start = datetime.now()
+
+        # Send a first message to show that the bot is responsive.
+        # We will edit this message later with the actual content.
+        msg = await ctx.send(i18n["queue"]["getting_queue"])
+
+        await msg.edit(
+            content=i18n["queue"]["embed_message"].format(
+                duration_str=get_duration_str(start)
+            )
+        )
+
+
+def setup(bot: ButtercupBot) -> None:
+    """Set up the Queue cog."""
+    cog_config = bot.config["Blossom"]
+    email = cog_config.get("email")
+    password = cog_config.get("password")
+    api_key = cog_config.get("api_key")
+    blossom_api = BlossomAPI(email=email, password=password, api_key=api_key)
+    bot.add_cog(Queue(bot=bot, blossom_api=blossom_api))
+
+
+def teardown(bot: ButtercupBot) -> None:
+    """Unload the Queue cog."""
+    bot.remove_cog("Queue")

--- a/buttercup/cogs/queue.py
+++ b/buttercup/cogs/queue.py
@@ -13,6 +13,7 @@ from discord_slash import SlashContext, cog_ext
 from discord_slash.model import SlashMessage
 
 from buttercup.bot import ButtercupBot
+from buttercup.cogs.find import COMPLETED_COLOR, IN_PROGRESS_COLOR, UNCLAIMED_COLOR
 from buttercup.cogs.helpers import (
     BlossomException,
     get_submission_source,
@@ -269,11 +270,20 @@ class Queue(Cog):
             )
         )
 
+        color = (
+            COMPLETED_COLOR
+            if unclaimed_count == 0
+            else IN_PROGRESS_COLOR
+            if claimed_count > 0
+            else UNCLAIMED_COLOR
+        )
+
         embed = Embed(
             title=i18n["queue"]["embed_title"],
             description=i18n["queue"]["embed_description"].format(
                 unclaimed_message=unclaimed_message, claimed_message=claimed_message,
             ),
+            color=color,
         )
 
         await msg.edit(

--- a/buttercup/cogs/search.py
+++ b/buttercup/cogs/search.py
@@ -21,9 +21,10 @@ from buttercup.cogs.helpers import (
     get_discord_time_str,
     get_duration_str,
     get_initial_username,
+    get_transcription_source,
     get_user,
     get_username,
-    parse_time_constraints, get_transcription_source,
+    parse_time_constraints,
 )
 from buttercup.strings import translation
 

--- a/buttercup/cogs/search.py
+++ b/buttercup/cogs/search.py
@@ -23,7 +23,7 @@ from buttercup.cogs.helpers import (
     get_initial_username,
     get_user,
     get_username,
-    parse_time_constraints,
+    parse_time_constraints, get_transcription_source,
 )
 from buttercup.strings import translation
 
@@ -59,13 +59,6 @@ def get_transcription_type(transcription: Dict[str, Any]) -> str:
         tr_type = tr_type.strip()
 
     return tr_type or tr_format
-
-
-def get_transcription_source(transcription: Dict[str, Any]) -> str:
-    """Try to determine the source (subreddit) of the transcription."""
-    # https://reddit.com/r/thatHappened/comments/qzhtyb/the_more_you_read_the_less_believable_it_gets/hlmkuau/
-    url: str = transcription["url"]
-    return "r/" + url.split("/")[4]
 
 
 def format_query_occurrence(line: str, line_num: int, pos: int, query: str) -> str:

--- a/buttercup/main.py
+++ b/buttercup/main.py
@@ -18,6 +18,7 @@ EXTENSIONS = [
     "ping",
     "rules",
     "leaderboard",
+    "queue",
 ]
 
 

--- a/buttercup/strings/en_US.yaml
+++ b/buttercup/strings/en_US.yaml
@@ -305,6 +305,6 @@ queue:
   claimed_message_cleared: |-
     There are no transcriptions in progress right now.
   claimed_list_entry: |-
-    - **{author}** on {source} {time}
+    - **{author}** on [{source}]({url}) {time}
   claimed_list_others: |-
     ...and {other_count} other(s).

--- a/buttercup/strings/en_US.yaml
+++ b/buttercup/strings/en_US.yaml
@@ -279,3 +279,8 @@ search:
     Results for `{query}` by {user}
   embed_footer: |-
     Page {cur_page}/{total_pages} ({total_results} result(s))
+queue:
+  getting_queue: |-
+    Getting the current status of the queue...
+  embed_message: |-
+    Here is the current status of the queue! ({duration_str})

--- a/buttercup/strings/en_US.yaml
+++ b/buttercup/strings/en_US.yaml
@@ -292,14 +292,19 @@ queue:
     {claimed_message}
   unclaimed_message: |-
     **Unclaimed**: {unclaimed_count}
-    {source_list}
+    {unclaimed_list}
   unclaimed_message_cleared: |-
     :tada: **The queue has been cleared!** :tada:
-  source_list_entry: |-
+  unclaimed_list_entry: |-
     - {count} from **{source}**
-  source_list_others: |-
+  unclaimed_list_others: |-
     ...and {post_count} from {source_count} other source(s).
   claimed_message: |-
     **In Progress**: {claimed_count}
+    {claimed_list}
   claimed_message_cleared: |-
     There are no transcriptions in progress right now.
+  claimed_list_entry: |-
+    - **{author}** on {source} {time}
+  claimed_list_others: |-
+    ...and {other_count} other(s).

--- a/buttercup/strings/en_US.yaml
+++ b/buttercup/strings/en_US.yaml
@@ -287,5 +287,13 @@ queue:
   embed_title: |-
     Queue Status
   embed_description: |-
+    {unclaimed_message}
+  unclaimed_message: |-
     **Unclaimed**: {unclaimed_count}
     {source_list}
+  unclaimed_message_cleared: |-
+    :tada: **The queue has been cleared!** :tada:
+  source_list_entry: |-
+    - {count} from **{source}**
+  source_list_others: |-
+    ...and {post_count} from {source_count} other source(s).

--- a/buttercup/strings/en_US.yaml
+++ b/buttercup/strings/en_US.yaml
@@ -283,7 +283,7 @@ queue:
   getting_queue: |-
     Getting the current status of the queue...
   embed_message: |-
-    Here is the current status of the queue! ({duration_str})
+    Here is the current status of the queue! (Last updated {last_updated})
   embed_title: |-
     Queue Status
   embed_description: |-

--- a/buttercup/strings/en_US.yaml
+++ b/buttercup/strings/en_US.yaml
@@ -288,6 +288,8 @@ queue:
     Queue Status
   embed_description: |-
     {unclaimed_message}
+
+    {claimed_message}
   unclaimed_message: |-
     **Unclaimed**: {unclaimed_count}
     {source_list}
@@ -297,3 +299,7 @@ queue:
     - {count} from **{source}**
   source_list_others: |-
     ...and {post_count} from {source_count} other source(s).
+  claimed_message: |-
+    **In Progress**: {claimed_count}
+  claimed_message_cleared: |-
+    There are no transcriptions in progress right now.

--- a/buttercup/strings/en_US.yaml
+++ b/buttercup/strings/en_US.yaml
@@ -287,4 +287,5 @@ queue:
   embed_title: |-
     Queue Status
   embed_description: |-
-    The queue currently contains {unclaimed} unclaimed posts!
+    **Unclaimed**: {unclaimed_count}
+    {source_list}

--- a/buttercup/strings/en_US.yaml
+++ b/buttercup/strings/en_US.yaml
@@ -284,3 +284,7 @@ queue:
     Getting the current status of the queue...
   embed_message: |-
     Here is the current status of the queue! ({duration_str})
+  embed_title: |-
+    Queue Status
+  embed_description: |-
+    The queue currently contains {unclaimed} unclaimed posts!

--- a/test/test_helpers.py
+++ b/test/test_helpers.py
@@ -2,7 +2,6 @@ from datetime import datetime, timedelta
 from typing import List, Optional
 
 import pytz
-from _pytest.mark import MARK_GEN
 from pytest import mark
 
 from buttercup.cogs.helpers import (
@@ -14,12 +13,13 @@ from buttercup.cogs.helpers import (
     format_absolute_datetime,
     format_relative_datetime,
     get_progress_bar,
+    get_transcription_source,
     get_username,
     join_items_with_and,
     parse_time_constraints,
     try_parse_time,
     username_regex,
-    utc_offset_to_str, get_transcription_source,
+    utc_offset_to_str,
 )
 
 

--- a/test/test_helpers.py
+++ b/test/test_helpers.py
@@ -2,6 +2,7 @@ from datetime import datetime, timedelta
 from typing import List, Optional
 
 import pytz
+from _pytest.mark import MARK_GEN
 from pytest import mark
 
 from buttercup.cogs.helpers import (
@@ -18,7 +19,7 @@ from buttercup.cogs.helpers import (
     parse_time_constraints,
     try_parse_time,
     username_regex,
-    utc_offset_to_str,
+    utc_offset_to_str, get_transcription_source,
 )
 
 
@@ -381,3 +382,23 @@ def test_parse_relative_time_constraints(
         assert actual_before is None
 
     assert actual_str == expected_str
+
+
+@mark.parametrize(
+    "url,expected",
+    [
+        (
+            "https://reddit.com/r/thatHappened/comments/qzhtyb/the_more_you_read_the_less_believable_it_gets/hlmkuau/",  # noqa: E501
+            "r/thatHappened",
+        ),
+        (
+            # noqa: E501
+            "https://reddit.com/r/CasualUK/comments/qzhsco/found_this_bag_of_mints_on_the_floor_which_is/hlmjpoa/",  # noqa: E501
+            "r/CasualUK",
+        ),
+    ],
+)
+def test_get_transcription_source(url: str, expected: str) -> None:
+    """Verify that the transcription source is determined correctly."""
+    tr_type = get_transcription_source({"url": url})
+    assert tr_type == expected

--- a/test/test_search.py
+++ b/test/test_search.py
@@ -4,7 +4,6 @@ from pytest import mark
 
 from buttercup.cogs.search import (
     SearchCache,
-    get_transcription_source,
     get_transcription_type,
 )
 
@@ -42,26 +41,6 @@ Footer"""
 def test_get_transcription_type(transcription: str, expected: str) -> None:
     """Verify that the transcription type is determined correctly."""
     tr_type = get_transcription_type({"text": transcription})
-    assert tr_type == expected
-
-
-@mark.parametrize(
-    "url,expected",
-    [
-        (
-            "https://reddit.com/r/thatHappened/comments/qzhtyb/the_more_you_read_the_less_believable_it_gets/hlmkuau/",  # noqa: E501
-            "r/thatHappened",
-        ),
-        (
-            # noqa: E501
-            "https://reddit.com/r/CasualUK/comments/qzhsco/found_this_bag_of_mints_on_the_floor_which_is/hlmjpoa/",  # noqa: E501
-            "r/CasualUK",
-        ),
-    ],
-)
-def test_get_transcription_source(url: str, expected: str) -> None:
-    """Verify that the transcription source is determined correctly."""
-    tr_type = get_transcription_source({"url": url})
     assert tr_type == expected
 
 


### PR DESCRIPTION
Relevant issue: Closes #42.

## Description:

This adds a `/queue` command to display the current status of the queue.

**Features**:

- Showing the number of unclaimed posts (see Future Work for limitations), as well as the number of posts per subreddit.
- Showing the number of claimed posts (last 48 hours), as well as the 5 most recent claims.
- The last 5 messages will be updated automatically every couple of minutes.

## Screenshots:

![The response of the queue command. It shows the number of unclaimed posts, as well as a breakdown by subreddit, as well as the number of in-progress posts, showing the 5 most recent claims.](https://user-images.githubusercontent.com/13908946/149629575-6e8d3b7f-5ebf-4d91-8505-0f985d84bf0f.png)

## Future Work:

- Synchronize the removed posts with Reddit (on Blossom). Right now, the number of unclaimed posts will be higher than on the subreddit, because we don't know which posts have been removed. This will also be important for the app.
- Recognize if a message has been pinned. Right now, only the last 5 messages are updated for performance reasons. Therefore, we cannot pin the queue message, because at some point it won't be updated anymore.

## Checklist:

- [x] Code Quality
- [x] Pep-8
- [ ] Tests (if applicable)
- [x] Success Criteria Met
- [x] Inline Documentation
- [ ] Wiki Documentation (if applicable)
