### PR TITLE
Don't count removed posts in the queue

### DIFF
--- a/buttercup/cogs/queue.py
+++ b/buttercup/cogs/queue.py
@@ -143,6 +143,7 @@ class Queue(Cog):
                     "completed_by__isnull": True,
                     "claimed_by__isnull": True,
                     "archived": False,
+                    "removed_from_queue": False,
                     "create_time__gte": queue_start.isoformat(),
                 },
             )
@@ -178,6 +179,7 @@ class Queue(Cog):
                     "completed_by__isnull": True,
                     "claimed_by__isnull": False,
                     "archived": False,
+                    "removed_from_queue": False,
                     "create_time__gte": queue_start.isoformat(),
                     "ordering": "-claim_time",
                 },


### PR DESCRIPTION
Relevant issue: N/A

## Description:

Quick PR to not count removed posts in the `/queue` command.

## Checklist:

- [x] Code Quality
- [x] Pep-8
- [ ] Tests (if applicable)
- [x] Success Criteria Met
- [ ] Inline Documentation
- [ ] Wiki Documentation (if applicable)
