### PR TITLE
Add recently completed transcriptions to `/queue` message

### DIFF
--- a/buttercup/cogs/queue.py
+++ b/buttercup/cogs/queue.py
@@ -357,6 +357,11 @@ class Queue(Cog):
 
     async def update_message(self, msg: SlashMessage) -> None:
         """Update the given message with the latest queue stats."""
+        if self.unclaimed is None or self.claimed is None or self.completed is None:
+            # No data available yet
+            await msg.edit(content=i18n["queue"]["embed_message_loading_queue"])
+            return
+
         unclaimed = self.unclaimed
         unclaimed_count = len(unclaimed.index)
 

--- a/buttercup/strings/en_US.yaml
+++ b/buttercup/strings/en_US.yaml
@@ -286,6 +286,9 @@ queue:
     Here is the current status of the queue! (Last updated {last_updated})
   embed_title: |-
     Queue Status
+  embed_description_loading_queue: |-
+    I'm currently loading the status of the queue.
+    If this message doesn't go away in a couple of minutes, please contact a moderator.
   embed_description: |-
     {unclaimed_message}
 

--- a/buttercup/strings/en_US.yaml
+++ b/buttercup/strings/en_US.yaml
@@ -290,6 +290,8 @@ queue:
     {unclaimed_message}
 
     {claimed_message}
+
+    {completed_message}
   unclaimed_message: |-
     **Unclaimed**: {unclaimed_count}
     {unclaimed_list}
@@ -308,3 +310,10 @@ queue:
     - **{author}** on [{source}]({url}) {time}
   claimed_list_others: |-
     ...and {other_count} other(s).
+  completed_message: |-
+    **Recently Completed**:
+    {completed_list}
+  completed_message_cleared: |-
+    There are no transcriptions in completed right now.
+  completed_list_entry: |-
+    - [{type}]({tr_url}) on [{source}]({url}) by **{author}** {time}


### PR DESCRIPTION
Relevant issue: Closes #171

## Description:

This adds the 5 most recently completed transcriptions to the `/queue` message.
I think we'll have to optimize our API to make the updates faster, but the info is definitely nice to have.

## Screenshots:

![The `/queue` response now also contains the last 5 completed transcriptions.](https://user-images.githubusercontent.com/13908946/150827553-c9373972-05b8-43dc-8170-f457c6e60621.png)

## Checklist:

- [x] Code Quality
- [x] Pep-8
- [ ] Tests (if applicable)
- [x] Success Criteria Met
- [x] Inline Documentation
- [ ] Wiki Documentation (if applicable)
