### PR TITLE
Add `/activity` command

### DIFF
--- a/buttercup/cogs/heatmap.py
+++ b/buttercup/cogs/heatmap.py
@@ -212,7 +212,9 @@ class Heatmap(Cog):
         ],
     )
     async def activity_map(
-        self, ctx: SlashContext, username: Optional[str] = "me",
+        self,
+        ctx: SlashContext,
+        username: Optional[str] = "me",
     ) -> None:
         """Generate a yearly activity heatmap for the given user."""
         start = datetime.now()
@@ -271,7 +273,8 @@ class Heatmap(Cog):
 
         await msg.edit(
             content=i18n["activity"]["response_message"].format(
-                user=get_username(user), duration=get_duration_str(start),
+                user=get_username(user),
+                duration=get_duration_str(start),
             ),
             file=activity_map,
         )

--- a/buttercup/cogs/heatmap.py
+++ b/buttercup/cogs/heatmap.py
@@ -156,7 +156,9 @@ def _create_file_from_activity_map(
     )
 
     ax.set_title(
-        i18n["activity"]["plot_title"].format(user=get_username(user, escape=False), time=time_str)
+        i18n["activity"]["plot_title"].format(
+            user=get_username(user, escape=False), time=time_str
+        )
     )
     # Remove axis labels
     ax.set_xlabel(None)
@@ -293,7 +295,11 @@ class Heatmap(Cog):
         _, before_time, _ = parse_time_constraints(None, before)
 
         # Then calculate the start time (one year before the end)
-        after = "1 year" if before_time is None else (before_time - timedelta(days=365)).isoformat()
+        after = (
+            "1 year"
+            if before_time is None
+            else (before_time - timedelta(days=365)).date().isoformat()
+        )
         # and get the string representing the time span
         after_time, _, time_str = parse_time_constraints(after, before)
 
@@ -335,7 +341,8 @@ class Heatmap(Cog):
 
         # All possible weeks, in case some are missing in the data
         all_week_indexes = [
-            _get_week_index((before_time or start) - timedelta(weeks=weeks)) for weeks in range(53)
+            _get_week_index((before_time or start) - timedelta(weeks=weeks))
+            for weeks in range(53)
         ]
 
         activity_df = (

--- a/buttercup/cogs/heatmap.py
+++ b/buttercup/cogs/heatmap.py
@@ -256,11 +256,11 @@ class Heatmap(Cog):
         rate_df = rate_df.set_index("date")
 
         # Add the week number
-        rate_df["week"] = rate_df.index.to_series().apply(lambda x: x.isocalendar()[1])
+        rate_df["week"] = rate_df.index.to_series().apply(
+            lambda x: x.isocalendar()[0] * 100 + x.isocalendar()[1]
+        )
         # Add the week day
         rate_df["day"] = rate_df.index.to_series().apply(lambda x: x.isocalendar()[2])
-
-        print(rate_df)
 
         activity_df = (
             # Create a data frame from the data

--- a/buttercup/cogs/heatmap.py
+++ b/buttercup/cogs/heatmap.py
@@ -4,7 +4,6 @@ from typing import List, Optional
 
 import matplotlib.pyplot as plt
 import pandas as pd
-import pytz
 import seaborn as sns
 from blossom_wrapper import BlossomAPI
 from dateutil import parser
@@ -276,7 +275,8 @@ class Heatmap(Cog):
             ),
             create_option(
                 name="before",
-                description="The end time of the activity map, it will show one year before this date.",
+                description="The end time of the activity map, "
+                "it will show one year before this date.",
                 option_type=3,
                 required=False,
             ),

--- a/buttercup/cogs/heatmap.py
+++ b/buttercup/cogs/heatmap.py
@@ -278,8 +278,6 @@ class Heatmap(Cog):
             )
         )
 
-        utc_offset = extract_utc_offset(ctx.author.display_name)
-
         from_str = after_time.isoformat() if after_time else None
         until_str = before_time.isoformat() if before_time else None
 
@@ -288,8 +286,8 @@ class Heatmap(Cog):
         rate_response = self.blossom_api.get(
             "submission/rate/",
             params={
+                "completed_by__isnull": False,
                 "completed_by": get_user_id(user),
-                "utc_offset": utc_offset,
                 "complete_time__gte": from_str,
                 "complete_time__lte": until_str,
                 "page_size": 365,
@@ -324,7 +322,7 @@ class Heatmap(Cog):
             .reindex(range(1, 8))
             .transpose()
             # Make sure all week numbers are present
-            .reindex(all_week_indexes)
+            .reindex(reversed(all_week_indexes))
             .transpose()
         )
 

--- a/buttercup/cogs/heatmap.py
+++ b/buttercup/cogs/heatmap.py
@@ -61,7 +61,9 @@ def create_file_from_heatmap(
 
     timezone = utc_offset_to_str(utc_offset)
 
-    plt.title(i18n["heatmap"]["plot_title"].format(user=get_username(user)))
+    plt.title(
+        i18n["heatmap"]["plot_title"].format(user=get_username(user, escape=False))
+    )
     plt.xlabel(i18n["heatmap"]["plot_xlabel"].format(timezone=timezone))
     plt.ylabel(i18n["heatmap"]["plot_ylabel"])
 
@@ -129,12 +131,18 @@ def _create_file_from_activity_map(
     fig, ax = plt.subplots()
     fig.set_size_inches(9, 3.44)
 
-    cbar_kws = {"orientation": "horizontal", "fraction": 0.08, "aspect": 40, "shrink": 0.6}
+    cbar_kws = {
+        "orientation": "horizontal",
+        "fraction": 0.08,
+        "aspect": 40,
+        "shrink": 0.6,
+    }
 
     sns.heatmap(
         activity_df,
         ax=ax,
         annot=annotations,
+        annot_kws={"fontsize": "x-small"},
         fmt="s",
         cbar=True,
         cbar_kws=cbar_kws,
@@ -143,7 +151,9 @@ def _create_file_from_activity_map(
         xticklabels=_get_month_annotations(activity_df),
     )
 
-    ax.set_title(i18n["activity"]["plot_title"].format(user=get_username(user)))
+    ax.set_title(
+        i18n["activity"]["plot_title"].format(user=get_username(user, escape=False))
+    )
     # Remove axis labels
     ax.set_xlabel(None)
     ax.set_ylabel(None)

--- a/buttercup/cogs/heatmap.py
+++ b/buttercup/cogs/heatmap.py
@@ -46,6 +46,7 @@ def create_file_from_heatmap(
     )
 
     fig, ax = plt.subplots()
+    fig: plt.Figure
     fig.set_size_inches(9, 3.44)
 
     sns.heatmap(
@@ -129,7 +130,10 @@ def _create_file_from_activity_map(
     )
 
     fig, ax = plt.subplots()
+    fig: plt.Figure
+    ax: plt.Axes
     fig.set_size_inches(9, 3.44)
+    fig.subplots_adjust(bottom=0.25, top=1, left=0.05, right=0.98, wspace=0, hspace=0)
 
     cbar_kws = {
         "orientation": "horizontal",
@@ -158,7 +162,6 @@ def _create_file_from_activity_map(
     ax.set_xlabel(None)
     ax.set_ylabel(None)
 
-    fig.tight_layout()
     activity_map = io.BytesIO()
     plt.savefig(activity_map, format="png")
     activity_map.seek(0)

--- a/buttercup/cogs/heatmap.py
+++ b/buttercup/cogs/heatmap.py
@@ -1,6 +1,6 @@
 import io
 from datetime import datetime, timedelta
-from typing import Optional, List
+from typing import List, Optional
 
 import matplotlib.pyplot as plt
 import pandas as pd

--- a/buttercup/cogs/history.py
+++ b/buttercup/cogs/history.py
@@ -377,7 +377,7 @@ class History(Cog):
             # Convert date strings to datetime objects
             new_frame["date"] = new_frame["date"].apply(lambda x: parser.parse(x))
             # Add the data to the list
-            rate_data = rate_data.append(new_frame.set_index("date"))
+            rate_data = pd.concat(rate_data, new_frame.set_index("date"))
 
             # Continue with the next page
             page += 1

--- a/buttercup/cogs/history.py
+++ b/buttercup/cogs/history.py
@@ -377,7 +377,7 @@ class History(Cog):
             # Convert date strings to datetime objects
             new_frame["date"] = new_frame["date"].apply(lambda x: parser.parse(x))
             # Add the data to the list
-            rate_data = pd.concat(rate_data, new_frame.set_index("date"))
+            rate_data = pd.concat([rate_data, new_frame.set_index("date")])
 
             # Continue with the next page
             page += 1

--- a/buttercup/strings/en_US.yaml
+++ b/buttercup/strings/en_US.yaml
@@ -163,11 +163,11 @@ activity:
     - Fri
     - Sat
     - Sun
-  plot_title: Yearly activity map for {user}
+  plot_title: Yearly activity map for {user} {time}
   plot_xlabel: Time ({timezone})
   plot_ylabel: Weekday
   response_message: |
-    Here is the yearly activity map for {user}! ({duration})
+    Here is the yearly activity map for {user} {time}! ({duration})
 rules:
   getting_rules: |
     Getting the rules for r/{0}...

--- a/buttercup/strings/en_US.yaml
+++ b/buttercup/strings/en_US.yaml
@@ -152,6 +152,22 @@ heatmap:
   plot_ylabel: Weekday
   response_message: |
     Here is the heatmap for {user} {time_str}! ({duration})
+activity:
+  getting_activity: |
+    Generating the yearly activity map for {user}...
+  days:
+    - Mon
+    - Tue
+    - Wed
+    - Thu
+    - Fri
+    - Sat
+    - Sun
+  plot_title: Yearly activity map for {user}
+  plot_xlabel: Time ({timezone})
+  plot_ylabel: Weekday
+  response_message: |
+    Here is the yearly activity map for {user}! ({duration})
 rules:
   getting_rules: |
     Getting the rules for r/{0}...


### PR DESCRIPTION
Relevant issue: Closes #184.

## Description:

This PR adds a new `/activity` command which displays a map showing the user's activity in the past year. 

Contrary to the `/heatmap` command, no data is being aggregated, only the activity in the one year time frame is being displayed. This allows us to see trends of activity throughout the year.

## Screenshots:

![Screenshot of the command being used in Discord](https://user-images.githubusercontent.com/13908946/182642042-d1622e34-e146-4247-987f-dc0331b8102a.png)

## Checklist:

- [x] Code Quality
- [x] Pep-8
- [ ] Tests (if applicable)
- [x] Success Criteria Met
- [x] Inline Documentation
- [ ] Wiki Documentation (if applicable)
