### PR TITLE
Fix arguments of rate and history commands

### DIFF
--- a/buttercup/cogs/history.py
+++ b/buttercup/cogs/history.py
@@ -377,7 +377,7 @@ class History(Cog):
             # Convert date strings to datetime objects
             new_frame["date"] = new_frame["date"].apply(lambda x: parser.parse(x))
             # Add the data to the list
-            rate_data = rate_data.append(new_frame.set_index("date"))
+            rate_data = pd.concat([rate_data, new_frame.set_index("date")])
 
             # Continue with the next page
             page += 1
@@ -475,7 +475,7 @@ class History(Cog):
     async def history(
         self,
         ctx: SlashContext,
-        usernames: str = "me",
+        users: str = "me",
         after: Optional[str] = None,
         before: Optional[str] = None,
     ) -> None:
@@ -490,12 +490,12 @@ class History(Cog):
         # We'll later edit this message with the actual content
         msg = await ctx.send(
             i18n["history"]["getting_history"].format(
-                users=get_initial_username_list(usernames, ctx),
+                users=get_initial_username_list(users, ctx),
                 time_str=time_str,
             )
         )
 
-        users = get_user_list(usernames, ctx, self.blossom_api)
+        users = get_user_list(users, ctx, self.blossom_api)
         if users:
             users.sort(key=lambda u: u["gamma"], reverse=True)
         colors = get_user_colors(users)
@@ -615,7 +615,7 @@ class History(Cog):
     async def rate(
         self,
         ctx: SlashContext,
-        usernames: str = "me",
+        users: str = "me",
         after: Optional[str] = None,
         before: Optional[str] = None,
     ) -> None:
@@ -630,12 +630,12 @@ class History(Cog):
         # We'll later edit this message with the actual content
         msg = await ctx.send(
             i18n["rate"]["getting_rate"].format(
-                users=get_initial_username_list(usernames, ctx),
+                users=get_initial_username_list(users, ctx),
                 time_str=time_str,
             )
         )
 
-        users = get_user_list(usernames, ctx, self.blossom_api)
+        users = get_user_list(users, ctx, self.blossom_api)
         if users:
             users.sort(key=lambda u: u["gamma"], reverse=True)
         colors = get_user_colors(users)


### PR DESCRIPTION
Relevant issue: None

## Description:

This fixes an error when executing the history and rate commands, because of an argument name mismatch.

Those were changed on the Discord side at some point, but not adjusted in the code.
Additionally, a deprecated Pandas command has been changed.

Notably the legend for multiple users seems to be bugged, showing a dot in the first color for the second user. I have no idea why and will move this to a different issue:

![The second user in the legend doesn't show as the correct color and has a dot instead of a line. The graph renders correctly though](https://user-images.githubusercontent.com/13908946/182667868-60f77702-0403-40e3-8ffa-c328bbd8fa36.png)

## Checklist:

- [ ] Code Quality
- [x] Pep-8
- [ ] Tests (if applicable)
- [x] Success Criteria Met
- [ ] Inline Documentation
- [ ] Wiki Documentation (if applicable)
