### PR TITLE
Fix feed parameter in `/search` command

### DIFF
--- a/buttercup/cogs/search.py
+++ b/buttercup/cogs/search.py
@@ -24,7 +24,7 @@ from buttercup.cogs.helpers import (
     get_transcription_source,
     get_user,
     get_username,
-    parse_time_constraints,
+    parse_time_constraints, extract_sub_name,
 )
 from buttercup.strings import translation
 
@@ -269,7 +269,8 @@ class Search(Cog):
 
         from_str = after_time.isoformat() if after_time else None
         until_str = before_time.isoformat() if before_time else None
-        feed = feed if feed else None
+        feed = "/r/" + extract_sub_name(feed) if feed else None
+        feed_str = feed if feed else "all feeds"
 
         request_page = (discord_page * self.discord_page_size) // self.request_page_size
 
@@ -299,7 +300,7 @@ class Search(Cog):
                     query=query,
                     user=get_username(user),
                     time_str=time_str,
-                    feed_str=feed if feed else "all feeds",
+                    feed_str=feed_str,
                     duration_str=get_duration_str(start),
                 )
             )
@@ -344,6 +345,7 @@ class Search(Cog):
                 query=query,
                 user=get_username(user),
                 time_str=time_str,
+                feed_str=feed_str,
                 duration_str=get_duration_str(start),
             ),
             embed=Embed(

--- a/buttercup/cogs/search.py
+++ b/buttercup/cogs/search.py
@@ -18,13 +18,14 @@ from buttercup.bot import ButtercupBot
 from buttercup.cogs.helpers import (
     BlossomException,
     BlossomUser,
+    extract_sub_name,
     get_discord_time_str,
     get_duration_str,
     get_initial_username,
     get_transcription_source,
     get_user,
     get_username,
-    parse_time_constraints, extract_sub_name,
+    parse_time_constraints,
 )
 from buttercup.strings import translation
 

--- a/buttercup/cogs/search.py
+++ b/buttercup/cogs/search.py
@@ -280,7 +280,7 @@ class Search(Cog):
                 "author": user_id,
                 "create_time__gte": from_str,
                 "create_time__lte": until_str,
-                "feed": feed,
+                "submission__feed__iexact": feed,
                 "url__isnull": False,
                 "ordering": "-create_time",
                 "page_size": self.request_page_size,

--- a/buttercup/strings/en_US.yaml
+++ b/buttercup/strings/en_US.yaml
@@ -290,7 +290,7 @@ search:
     more_occurrences: |-
       ... and {count} more occurrence(s).
   embed_message: |-
-    Here are your results for `{query}` in transcriptions by {user} {time_str}! ({duration_str})
+    Here are your results for `{query}` in transcriptions by {user} {time_str} in {feed_str}! ({duration_str})
   embed_title: |-
     Results for `{query}` by {user}
   embed_footer: |-


### PR DESCRIPTION
Relevant issue: Closes #202

## Description:

- Fixes feed parameter using the wrong query filter in Blossom
- Fix final message not containing feed
- Make `/r/` prefix optional in feed parameter
- Make feed parameter case insensitive

## Checklist:

- [x] Code Quality
- [ ] Pep-8
- [ ] Tests (if applicable)
- [ ] Success Criteria Met
- [ ] Inline Documentation
- [ ] Wiki Documentation (if applicable)
